### PR TITLE
Feature/synapse workers

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -34,6 +34,15 @@ pub fn llama_server_path() -> PathBuf {
     bin_dir().join(name)
 }
 
+pub fn rpc_server_path() -> PathBuf {
+    let name = if cfg!(windows) {
+        "rpc-server.exe"
+    } else {
+        "rpc-server"
+    };
+    bin_dir().join(name)
+}
+
 pub fn sd_binary_path() -> PathBuf {
     let name = if cfg!(windows) { "sd.exe" } else { "sd" };
     bin_dir().join(name)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod models;
 mod rag;
 mod sd;
 mod server;
+mod synapse;
 
 use llama::{LlamaSettings, LlamaState, LlamaStatus};
 use models::{InstalledModel, ModelKind, ModelListing};
@@ -13,12 +14,14 @@ use rag::{Document, RagState, RetrievedChunk};
 use sd::{SdImage, SdRequest, SdState};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use synapse::{SynapseState, SynapseWorkerStatus};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 struct AppStateHolder {
     llama: Arc<LlamaState>,
     rag: Arc<RagState>,
     sd: Arc<SdState>,
+    synapse: Arc<SynapseState>,
     lan_url: parking_lot_lite::Once<String>,
     pin: String,
     #[allow(dead_code)]
@@ -220,6 +223,31 @@ async fn ensure_sd(app: AppHandle) -> Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+async fn start_synapse_worker(
+    app: AppHandle,
+    state: State<'_, Arc<AppStateHolder>>,
+    port: Option<u16>,
+) -> Result<SynapseWorkerStatus, String> {
+    state
+        .synapse
+        .start_worker(&app, port)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn stop_synapse_worker(state: State<'_, Arc<AppStateHolder>>) -> Result<(), String> {
+    state.synapse.stop_worker().await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn synapse_worker_status(
+    state: State<'_, Arc<AppStateHolder>>,
+) -> Result<SynapseWorkerStatus, String> {
+    Ok(state.synapse.status().await)
+}
+
 fn generate_pin() -> String {
     let raw = uuid::Uuid::new_v4().as_u128();
     format!("{:06}", (raw % 1_000_000) as u32)
@@ -230,12 +258,14 @@ pub fn run() {
     let llama = LlamaState::new();
     let rag = RagState::new();
     let sd = SdState::new();
+    let synapse = SynapseState::new();
     let pin = generate_pin();
     let tokens = Arc::new(Mutex::new(HashSet::new()));
     let holder = Arc::new(AppStateHolder {
         llama: llama.clone(),
         rag: rag.clone(),
         sd: sd.clone(),
+        synapse: synapse.clone(),
         lan_url: parking_lot_lite::Once::new(),
         pin: pin.clone(),
         tokens: tokens.clone(),
@@ -290,6 +320,9 @@ pub fn run() {
             sd_generate,
             sd_busy,
             ensure_sd,
+            start_synapse_worker,
+            stop_synapse_worker,
+            synapse_worker_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -18,6 +18,10 @@ pub struct LlamaSettings {
     pub port: Option<u16>,
     pub mmproj_id: Option<String>,
     pub flash_attn: Option<bool>,
+    /// Comma-separated `host:port` Synapse workers (Phase 1: manual entry).
+    /// When set, llama-server is launched with `--rpc <list>` so layers are
+    /// pipeline-sharded across this host plus each worker.
+    pub synapse_workers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -134,6 +138,21 @@ impl LlamaState {
         } else {
             "off"
         });
+        // Synapse: pipeline-shard layers across remote rpc-server workers.
+        // Validated upstream (frontend trims/filters), but we also drop empties
+        // here so a stray comma can't turn into "--rpc ,host:port".
+        if let Some(workers) = &settings.synapse_workers {
+            let csv = workers
+                .iter()
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join(",");
+            if !csv.is_empty() {
+                cmd.arg("--rpc").arg(&csv);
+            }
+        }
+
         let mut loaded_mmproj: Option<String> = None;
         if let Some(mmproj_id) = &settings.mmproj_id {
             if let Ok(p) = models::model_path(mmproj_id) {
@@ -241,7 +260,7 @@ fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {
     }
 }
 
-async fn kill_orphan_on_port(port: u16) {
+pub(crate) async fn kill_orphan_on_port(port: u16) {
     #[cfg(target_family = "unix")]
     {
         let out = tokio::process::Command::new("lsof")

--- a/src-tauri/src/synapse.rs
+++ b/src-tauri/src/synapse.rs
@@ -1,0 +1,136 @@
+// Phase 1 Synapse: each machine can run an `rpc-server` child process that
+// llama.cpp on a remote host reaches via `--rpc host:port`. Together the
+// machines form a pipeline-parallel inference cluster. Discovery, pairing, and
+// auto-split come in later phases — for now we just expose start/stop/status
+// for the worker, and let the host paste worker addresses manually.
+use crate::{binaries, config};
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+use std::process::Stdio;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+pub const DEFAULT_WORKER_PORT: u16 = 50052;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SynapseWorkerStatus {
+    pub running: bool,
+    pub port: u16,
+    pub pid: Option<u32>,
+}
+
+struct WorkerHandle {
+    child: Option<Child>,
+    port: u16,
+}
+
+pub struct SynapseState {
+    worker: Mutex<WorkerHandle>,
+}
+
+impl SynapseState {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            worker: Mutex::new(WorkerHandle {
+                child: None,
+                port: DEFAULT_WORKER_PORT,
+            }),
+        })
+    }
+
+    pub async fn status(&self) -> SynapseWorkerStatus {
+        let w = self.worker.lock().await;
+        SynapseWorkerStatus {
+            running: w.child.is_some(),
+            port: w.port,
+            pid: w.child.as_ref().and_then(|c| c.id()),
+        }
+    }
+
+    pub async fn stop_worker(&self) -> Result<()> {
+        let mut w = self.worker.lock().await;
+        if let Some(mut c) = w.child.take() {
+            let _ = c.kill().await;
+        }
+        Ok(())
+    }
+
+    pub async fn start_worker(
+        &self,
+        app: &AppHandle,
+        port: Option<u16>,
+    ) -> Result<SynapseWorkerStatus> {
+        // Make sure the llama.cpp bundle is unpacked — `rpc-server` ships in
+        // the same archive as `llama-server`, so we trigger that download here
+        // if the user toggles worker mode before they've ever loaded a model.
+        binaries::ensure_llama_server(app).await?;
+
+        self.stop_worker().await?;
+        let port = port.unwrap_or(DEFAULT_WORKER_PORT);
+        crate::llama::kill_orphan_on_port(port).await;
+
+        let binary = config::rpc_server_path();
+        if !binary.exists() {
+            return Err(anyhow!(
+                "rpc-server binary not found at {} — is the bundled llama.cpp build missing RPC support?",
+                binary.display()
+            ));
+        }
+
+        // Bind to 0.0.0.0 so other machines on the LAN can connect; the host
+        // typed our address into its workers field. There's no auth on the RPC
+        // wire (Phase 2 will fix that with an auth shim) — only run worker
+        // mode on networks you control.
+        let mut cmd = Command::new(&binary);
+        cmd.arg("-H").arg("0.0.0.0");
+        cmd.arg("-p").arg(port.to_string());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| anyhow!("failed to spawn rpc-server: {e}"))?;
+        pipe_output(app, &mut child);
+
+        {
+            let mut w = self.worker.lock().await;
+            w.child = Some(child);
+            w.port = port;
+        }
+
+        let _ = app.emit("synapse:ready", serde_json::json!({ "port": port }));
+
+        Ok(self.status().await)
+    }
+}
+
+fn pipe_output(app: &AppHandle, child: &mut Child) {
+    if let Some(stdout) = child.stdout.take() {
+        let app = app.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({ "stream": "stdout", "line": line }),
+                );
+            }
+        });
+    }
+    if let Some(stderr) = child.stderr.take() {
+        let app = app.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({ "stream": "stderr", "line": line }),
+                );
+            }
+        });
+    }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   RetrievedChunk,
   SdImage,
   SdRequest,
+  SynapseWorkerStatus,
 } from "./types";
 
 function connection() {
@@ -105,6 +106,10 @@ export const api = {
   sdBusy: () => invoke<boolean>("sd_busy"),
   ensureSd: () => invoke<string>("ensure_sd"),
   getLanPin: () => invoke<string>("get_lan_pin"),
+  startSynapseWorker: (port?: number) =>
+    invoke<SynapseWorkerStatus>("start_synapse_worker", { port }),
+  stopSynapseWorker: () => invoke<void>("stop_synapse_worker"),
+  synapseWorkerStatus: () => invoke<SynapseWorkerStatus>("synapse_worker_status"),
 };
 
 export type ChatContentPart =

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -81,6 +81,14 @@ interface AppState {
   // null on desktop (Tauri) — desktop talks to its own backend via invoke().
   connection: { url: string; token: string } | null;
   setConnection: (c: { url: string; token: string } | null) => void;
+
+  // Synapse: distributed inference across LAN machines (Phase 1: manual).
+  // `workers` is a list of `host:port` strings the host appends as `--rpc`.
+  // `workerEnabled` reflects whether *this* machine is running rpc-server.
+  synapse: { workerEnabled: boolean; workerPort: number; workers: string[] };
+  setSynapseWorkerEnabled: (enabled: boolean) => void;
+  setSynapseWorkerPort: (port: number) => void;
+  setSynapseWorkers: (workers: string[]) => void;
 }
 
 const emptyLlama: LlamaStatus = {
@@ -194,6 +202,14 @@ export const useApp = create<AppState>()(
 
       connection: null,
       setConnection: (c) => set({ connection: c }),
+
+      synapse: { workerEnabled: false, workerPort: 50052, workers: [] },
+      setSynapseWorkerEnabled: (workerEnabled) =>
+        set((s) => ({ synapse: { ...s.synapse, workerEnabled } })),
+      setSynapseWorkerPort: (workerPort) =>
+        set((s) => ({ synapse: { ...s.synapse, workerPort } })),
+      setSynapseWorkers: (workers) =>
+        set((s) => ({ synapse: { ...s.synapse, workers } })),
     }),
     {
       name: "localmind-store",
@@ -206,6 +222,7 @@ export const useApp = create<AppState>()(
         activeSdModelId: s.activeSdModelId,
         sdImages: s.sdImages,
         connection: s.connection,
+        synapse: s.synapse,
       }),
     },
   ),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,14 @@ export interface LlamaSettings {
   port?: number;
   mmprojId?: string;
   flashAttn?: boolean;
+  /** Synapse: comma-separated `host:port` workers to pipeline-shard layers across. */
+  synapseWorkers?: string[];
+}
+
+export interface SynapseWorkerStatus {
+  running: boolean;
+  port: number;
+  pid: number | null;
 }
 
 export interface ModelDownloadProgress {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -16,7 +16,7 @@ export function Chat({ onOpenMenu }: { onOpenMenu?: () => void } = {}) {
   const {
     conversations, activeConvId, createConversation, updateConversation, renameConversation,
     activeModelId, setActiveModelId, installed, llama, setLlama, setView,
-    ragDocs, setRagDocs, toggleRagDoc,
+    ragDocs, setRagDocs, toggleRagDoc, synapse,
   } = useApp();
   const remote = !isTauri();
   // On the phone we don't pick a model — we use whatever the host has loaded.
@@ -75,7 +75,8 @@ export function Chat({ onOpenMenu }: { onOpenMenu?: () => void } = {}) {
     if (llama.running && llama.modelId === modelId && (llama.mmprojId ?? undefined) === wantMmproj) {
       return;
     }
-    const status = await api.startLlama({ modelId, mmprojId: wantMmproj });
+    const synapseWorkers = synapse.workers.length > 0 ? synapse.workers : undefined;
+    const status = await api.startLlama({ modelId, mmprojId: wantMmproj, synapseWorkers });
     setLlama(status);
   }
 

--- a/src/pages/Models.tsx
+++ b/src/pages/Models.tsx
@@ -5,7 +5,7 @@ import { useApp } from "../lib/store";
 import { formatBytes } from "../lib/util";
 
 export function Models() {
-  const { installed, setInstalled, activeModelId, setActiveModelId, llama, setLlama, setView } = useApp();
+  const { installed, setInstalled, activeModelId, setActiveModelId, llama, setLlama, setView, synapse } = useApp();
 
   useEffect(() => {
     api.listInstalledModels().then(setInstalled).catch(console.error);
@@ -27,7 +27,8 @@ export function Models() {
     const mmprojId = model?.kind === "vision"
       ? (mmprojs.find((m) => m.repo === model.repo) ?? mmprojs[0])?.id
       : undefined;
-    const s = await api.startLlama({ modelId: id, mmprojId });
+    const synapseWorkers = synapse.workers.length > 0 ? synapse.workers : undefined;
+    const s = await api.startLlama({ modelId: id, mmprojId, synapseWorkers });
     setLlama(s);
   }
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Cpu, Wifi, Smartphone, Copy, Check, KeyRound, LogOut, Network, Power } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Cpu, Wifi, Smartphone, Copy, Check, KeyRound, LogOut, Network, Power, Terminal, Trash2 } from "lucide-react";
 import QRCode from "qrcode";
 import { useApp } from "../lib/store";
 import { api } from "../lib/api";
@@ -24,6 +24,18 @@ export function Settings() {
   // save / on every keystroke to keep the persisted store in `string[]` form.
   const [workersText, setWorkersText] = useState(synapse.workers.join(", "));
 
+  // Synapse log panel: rolling buffer fed by `llama:log` (host's llama-server)
+  // and `synapse:log` (this machine's rpc-server when worker mode is on).
+  // We keep raw entries so the "Highlights" filter can be toggled without
+  // dropping lines, and bound the buffer at MAX_LOG_LINES to avoid leaking RAM
+  // over a long session.
+  const MAX_LOG_LINES = 400;
+  type LogEntry = { source: "llama" | "synapse"; stream: string; line: string; tag?: string };
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [highlightsOnly, setHighlightsOnly] = useState(true);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const logBoxRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (remote) return;
     listen<BinaryProgress>("binary:progress", (p) => setEngineProgress(p));
@@ -34,6 +46,44 @@ export function Settings() {
       .then((s) => setSynapseWorkerEnabled(s.running))
       .catch(() => {});
   }, [remote, setSynapseWorkerEnabled]);
+
+  // Subscribe to log streams from both llama-server and rpc-server. Both
+  // emitters live in Rust (`pipe_output` in llama.rs / synapse.rs) and emit
+  // structured JSON. The promise→fn dance is so we can `await` the unsubscribe
+  // when the component unmounts — `listen()` resolves to a fn, not an unsub.
+  useEffect(() => {
+    if (remote) return;
+    let pending: Array<() => void> = [];
+    let cancelled = false;
+
+    const append = (entry: LogEntry) => {
+      setLogs((prev) => {
+        const next = prev.concat(entry);
+        // O(1) trim at the head when we exceed the cap. We pay slice() instead
+        // of mutating in place because React needs a new reference to re-render.
+        return next.length > MAX_LOG_LINES ? next.slice(next.length - MAX_LOG_LINES) : next;
+      });
+    };
+
+    listen<{ stream: string; line: string; tag?: string }>("llama:log", (p) => {
+      append({ source: "llama", stream: p.stream, line: p.line, tag: p.tag });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<{ stream: string; line: string }>("synapse:log", (p) => {
+      append({ source: "synapse", stream: p.stream, line: p.line });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    return () => {
+      cancelled = true;
+      pending.forEach((un) => un());
+    };
+  }, [remote]);
+
+  useEffect(() => {
+    if (autoScroll && logBoxRef.current) {
+      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+    }
+  }, [logs, autoScroll]);
 
   async function toggleWorker(next: boolean) {
     setWorkerBusy(true);
@@ -264,6 +314,90 @@ export function Settings() {
                 </div>
               )}
             </div>
+
+            {/* Live log panel — surfaces stdout/stderr from llama-server (host)
+                and rpc-server (worker) so users can confirm RPC is engaged.
+                "Highlights" filter narrows to lines mentioning RPC / offload /
+                buffer-size, which is what you actually want when debugging
+                whether layers landed on the worker. */}
+            <div className="mt-5">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <Terminal size={13} className="text-[var(--color-text-muted)]" />
+                  Live logs
+                  <span className="text-xs text-[var(--color-text-subtle)] font-normal">
+                    ({logs.length}/{MAX_LOG_LINES})
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={highlightsOnly}
+                      onChange={(e) => setHighlightsOnly(e.target.checked)}
+                      className="accent-[var(--color-accent)]"
+                    />
+                    Highlights
+                  </label>
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={autoScroll}
+                      onChange={(e) => setAutoScroll(e.target.checked)}
+                      className="accent-[var(--color-accent)]"
+                    />
+                    Auto-scroll
+                  </label>
+                  <button
+                    onClick={() => setLogs([])}
+                    className="flex items-center gap-1 hover:text-[var(--color-text)]"
+                    title="Clear logs"
+                  >
+                    <Trash2 size={12} />
+                    Clear
+                  </button>
+                </div>
+              </div>
+              <div
+                ref={logBoxRef}
+                className="font-mono text-[11px] leading-[1.45] bg-black/60 border border-[var(--color-border)] rounded-md p-2.5 h-[220px] overflow-y-auto"
+              >
+                {logs.length === 0 ? (
+                  <div className="text-[var(--color-text-subtle)] italic">
+                    Waiting for output… Load a model to see llama-server initialize, or start
+                    worker mode to see rpc-server output.
+                  </div>
+                ) : (
+                  logs
+                    .filter((l) => !highlightsOnly || isHighlight(l.line))
+                    .map((l, i) => (
+                      <div
+                        key={i}
+                        className={
+                          l.stream === "stderr"
+                            ? "text-[var(--color-text-muted)]"
+                            : "text-[var(--color-text)]"
+                        }
+                      >
+                        <span
+                          className={
+                            l.source === "synapse"
+                              ? "text-[var(--color-accent)]"
+                              : "text-[var(--color-success)]"
+                          }
+                        >
+                          [{l.source === "synapse" ? "rpc-server" : `llama-${l.tag ?? "server"}`}]
+                        </span>{" "}
+                        {l.line}
+                      </div>
+                    ))
+                )}
+              </div>
+              <div className="mt-1.5 text-[11px] text-[var(--color-text-subtle)]">
+                Highlights: lines mentioning <code>RPC</code>, <code>offload</code>,
+                <code> buffer size</code>, or errors — the signals that confirm a layer split actually happened.
+              </div>
+            </div>
           </Section>
         )}
       </div>
@@ -290,6 +424,15 @@ function Row({ k, v }: { k: string; v: string }) {
       <div className="text-right break-all">{v}</div>
     </div>
   );
+}
+
+// Pre-compiled regex for the "interesting" log lines that prove distributed
+// inference is actually engaged. Anything mentioning RPC backend registration,
+// the buffer-size table at load, layer offloading, or hard errors qualifies.
+const HIGHLIGHT_RE =
+  /\b(rpc|offload|buffer size|backend|n_layer|tensor split|error|failed|timeout)\b/i;
+function isHighlight(line: string): boolean {
+  return HIGHLIGHT_RE.test(line);
 }
 
 function describeAcc(a: any): string {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Cpu, Wifi, Smartphone, Copy, Check, KeyRound, LogOut } from "lucide-react";
+import { Cpu, Wifi, Smartphone, Copy, Check, KeyRound, LogOut, Network, Power } from "lucide-react";
 import QRCode from "qrcode";
 import { useApp } from "../lib/store";
 import { api } from "../lib/api";
@@ -8,19 +8,60 @@ import { listen } from "../lib/api";
 import { isTauri } from "../lib/util";
 
 export function Settings() {
-  const { hardware, lanUrl, connection, setConnection } = useApp();
+  const {
+    hardware, lanUrl, connection, setConnection,
+    synapse, setSynapseWorkerEnabled, setSynapseWorkerPort, setSynapseWorkers,
+  } = useApp();
   const remote = !isTauri();
   const [engineStatus, setEngineStatus] = useState<string>("not checked");
   const [engineProgress, setEngineProgress] = useState<BinaryProgress | null>(null);
   const [copied, setCopied] = useState<"url" | "pin" | null>(null);
   const [pin, setPin] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [workerBusy, setWorkerBusy] = useState(false);
+  const [workerError, setWorkerError] = useState<string | null>(null);
+  // Edited as a single string so the user can type commas freely; we split on
+  // save / on every keystroke to keep the persisted store in `string[]` form.
+  const [workersText, setWorkersText] = useState(synapse.workers.join(", "));
 
   useEffect(() => {
     if (remote) return;
     listen<BinaryProgress>("binary:progress", (p) => setEngineProgress(p));
     api.getLanPin().then(setPin).catch(() => {});
-  }, [remote]);
+    // Reconcile the store toggle with whatever the backend actually has running
+    // (e.g. after a desktop restart with worker mode previously enabled).
+    api.synapseWorkerStatus()
+      .then((s) => setSynapseWorkerEnabled(s.running))
+      .catch(() => {});
+  }, [remote, setSynapseWorkerEnabled]);
+
+  async function toggleWorker(next: boolean) {
+    setWorkerBusy(true);
+    setWorkerError(null);
+    try {
+      if (next) {
+        const status = await api.startSynapseWorker(synapse.workerPort);
+        setSynapseWorkerEnabled(status.running);
+        setSynapseWorkerPort(status.port);
+      } else {
+        await api.stopSynapseWorker();
+        setSynapseWorkerEnabled(false);
+      }
+    } catch (e: any) {
+      setWorkerError(e?.message ?? String(e));
+    } finally {
+      setWorkerBusy(false);
+    }
+  }
+
+  function commitWorkersText(text: string) {
+    setWorkersText(text);
+    const parsed = text
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setSynapseWorkers(parsed);
+  }
 
   // Render a QR encoding {url, pin} JSON so a future scan-to-pair flow can
   // populate both fields in one tap.
@@ -148,6 +189,79 @@ export function Settings() {
                   alt="Scan from phone to copy URL + PIN"
                   className="w-[160px] h-[160px] rounded-md border border-[var(--color-border)] bg-white"
                 />
+              )}
+            </div>
+          </Section>
+        )}
+
+        {!remote && (
+          <Section title="Synapse — pool machines on your LAN" icon={<Network size={15} />}>
+            <p className="text-sm text-[var(--color-text-muted)] mb-4">
+              Run a model whose weights don't fit on one machine by pipeline-sharding layers across multiple
+              computers on your local Wi-Fi. <span className="text-[var(--color-text-subtle)]">Phase 1 (manual): toggle worker mode below on each helper machine, then list their addresses on the host. Wired Ethernet is strongly recommended for tokens/sec.</span>
+            </p>
+
+            <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-panel-2)] p-3 mb-4">
+              <div className="flex items-start gap-3">
+                <Power
+                  size={15}
+                  className={synapse.workerEnabled ? "text-[var(--color-success)] mt-0.5" : "text-[var(--color-text-muted)] mt-0.5"}
+                />
+                <div className="flex-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-medium">Run as a Synapse worker</div>
+                      <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
+                        Spawns <code>rpc-server</code> on this machine so a host can offload layers to it.
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => toggleWorker(!synapse.workerEnabled)}
+                      disabled={workerBusy}
+                      className={`text-sm px-3 py-1.5 rounded-md border ${
+                        synapse.workerEnabled
+                          ? "bg-[var(--color-success)]/10 border-[var(--color-success)]/40 text-[var(--color-success)]"
+                          : "bg-[var(--color-panel)] border-[var(--color-border)] hover:border-[var(--color-accent)]/60"
+                      } disabled:opacity-50`}
+                    >
+                      {workerBusy ? "…" : synapse.workerEnabled ? "Stop worker" : "Start worker"}
+                    </button>
+                  </div>
+                  <div className="mt-3 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+                    <span>Listen port:</span>
+                    <input
+                      type="number"
+                      value={synapse.workerPort}
+                      disabled={synapse.workerEnabled}
+                      onChange={(e) => setSynapseWorkerPort(parseInt(e.target.value, 10) || 50052)}
+                      className="w-20 bg-[var(--color-panel)] border border-[var(--color-border)] rounded px-2 py-0.5 text-[var(--color-text)] disabled:opacity-50"
+                    />
+                    <span className="text-[var(--color-text-subtle)]">(default 50052)</span>
+                  </div>
+                  {workerError && (
+                    <div className="mt-2 text-xs text-[var(--color-danger)]">{workerError}</div>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <div className="text-sm font-medium mb-1">Workers (this machine is the host)</div>
+              <div className="text-xs text-[var(--color-text-muted)] mb-2">
+                Comma-separated <code>host:port</code>. Leave empty to run a model only on this machine.
+              </div>
+              <textarea
+                value={workersText}
+                onChange={(e) => commitWorkersText(e.target.value)}
+                placeholder="192.168.1.50:50052, mac-mini.local:50052"
+                rows={2}
+                className="w-full text-sm font-mono bg-[var(--color-panel-2)] border border-[var(--color-border)] rounded-md px-3 py-2 placeholder:text-[var(--color-text-subtle)]"
+              />
+              {synapse.workers.length > 0 && (
+                <div className="mt-2 text-xs text-[var(--color-text-muted)]">
+                  {synapse.workers.length} worker{synapse.workers.length === 1 ? "" : "s"} configured · applied
+                  on the next model load.
+                </div>
               )}
             </div>
           </Section>


### PR DESCRIPTION
## Synapse Phase 1 — distributed inference over LAN (manual RPC)

### Summary

Adds **Synapse**, LocalMind's distributed compute feature. Phase 1 lets users manually pool GPU/CPU resources from multiple machines on the same LAN to run models that are too large for any single device. A secondary machine acts as an RPC worker; the primary host shards model layers across both machines via llama.cpp's built-in `--rpc` mechanism.

Verified end-to-end: a 1.5B Q4 model split between an M1 Pro MacBook (host) and a Windows GPU machine (worker) — 540 MB of weights transferred over LAN, TCP connection confirmed `ESTABLISHED`, inference running distributed.

---

### What changed

#### Backend (Rust)

| File | Change |
|------|--------|
| `src-tauri/src/synapse.rs` | **New.** `SynapseState` manages the `rpc-server` child process — start, stop, status. Binds to `0.0.0.0` so LAN peers can connect. Pipes stdout/stderr as `synapse:log` Tauri events. |
| `src-tauri/src/llama.rs` | Added `synapse_workers: Option<Vec<String>>` to `LlamaSettings`. When non-empty, appends `--rpc <host:port,...>` to the llama-server launch command. Made `kill_orphan_on_port` `pub(crate)`. |
| `src-tauri/src/config.rs` | Added `rpc_server_path()` — resolves platform-correct path to the `rpc-server` binary (ships in the same archive as `llama-server`). |
| `src-tauri/src/lib.rs` | Wired `SynapseState` into `AppStateHolder`. Registered three new Tauri commands: `start_synapse_worker`, `stop_synapse_worker`, `synapse_worker_status`. |

#### Frontend (TypeScript / React)

| File | Change |
|------|--------|
| `src/lib/types.ts` | Added `synapseWorkers?: string[]` to `LlamaSettings`; new `SynapseWorkerStatus` type. |
| `src/lib/store.ts` | Added `synapse` slice — `workerEnabled`, `workerPort`, `workers[]`. Persisted to `localmind-store`. |
| `src/lib/api.ts` | Added `startSynapseWorker`, `stopSynapseWorker`, `synapseWorkerStatus`. |
| `src/pages/Settings.tsx` | New **Synapse** section: worker toggle, port input, workers textarea (one `host:port` per line). Live logs panel subscribed to both `llama:log` and `synapse:log` events — rolling 400-line buffer, highlight filter, auto-scroll, clear. |
| `src/pages/Chat.tsx` | Passes `synapse.workers` to `startLlama` when non-empty. |
| `src/pages/Models.tsx` | Same — worker list forwarded when activating a model from the library. |

---

### How to test

**On the worker machine:**
1. Download LocalMind and go to **Settings → Synapse**
2. Enable **Worker mode** and click **Start worker** (default port 50052)
3. Open port 50052 inbound in your firewall if needed
4. Note the machine's LAN IP (`ipconfig` / `ip a`)

**On the host machine:**
1. Go to **Settings → Synapse → Remote workers**
2. Add the worker's address: `192.168.x.x:50052`
3. Load any model from **Models** or **Chat**
4. In the live logs panel, you should see:
   - `[rpc-server]` lines confirming buffer allocation on the worker
   - `ggml_backend_rpc_buffer_type` entries showing offloaded layers

**Verify connectivity** (optional): `nc -zv <worker-ip> 50052` should print `succeeded`.

---

### Architecture

```
┌─────────────────────────┐         LAN            ┌──────────────────────────┐
│   Host (your Mac)       │  ──── TCP 50052 ────▶  │   Worker (any machine)   │
│                         │                        │                          │
│  llama-server           │   layer weights →      │  rpc-server              │
│    --rpc 192.168.x.x    │ ← activations ─        │    -H 0.0.0.0 -p 50052   │
│                         │                        │                          │
│  LocalMind UI           │                        │  LocalMind (worker mode) │
└─────────────────────────┘                        └──────────────────────────┘
```

---

### Known limitations (to be addressed in Phase 2+)

- **No auto-discovery** — worker addresses must be typed in manually
- **No auth on the RPC port** — only use this on networks you control; the RPC wire has no encryption or authentication (Phase 2 will add an auth shim)
- **Workers must run the same llama.cpp build** — binary ABI must match; mismatches will silently fail
- **Memory isn't guaranteed free on Wi-Fi drops** — if the TCP connection drops unexpectedly, the worker's VRAM may stay allocated until rpc-server is restarted (tracked, fix planned)
- **No smart layer split** — llama.cpp distribides layers automatically; no UI to control the split ratio (Phase 3)

