### PR TITLE
feat: ship prebuilt installers via Tauri NSIS bundler + tauri-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  release:
+    types: [created, published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop:
+    name: Desktop (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux system deps
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build and upload (release / tag)
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: "${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          releaseName: "LocalMind ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          releaseDraft: ${{ github.event_name != 'release' }}
+          prerelease: false
+          releaseBody: |
+            **Downloads**
+            - Windows: `LocalMind_*_x64-setup.exe`
+            - macOS: `LocalMind_*.dmg`
+            - Linux: `localmind_*_amd64.deb` / `LocalMind_*_amd64.AppImage`
+            - Android: `LocalMind_*_android-debug.apk` (tech preview)
+
+      - name: Build only (workflow_dispatch dry run)
+        if: github.event_name == 'workflow_dispatch'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  android:
+    name: Android (APK)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+        with:
+          packages: 'platform-tools platforms;android-34 build-tools;34.0.0 ndk;26.1.10909125'
+
+      - name: Export NDK_HOME
+        run: |
+          echo "NDK_HOME=$ANDROID_HOME/ndk/26.1.10909125" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/26.1.10909125" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: android
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Initialize Tauri Android project
+        run: npm run tauri android init
+
+      - name: Build APK (debug)
+        run: npm run tauri android build -- --apk --debug
+
+      - name: Locate APK
+        id: apk
+        run: |
+          APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' | head -n 1)
+          if [ -z "$APK" ]; then
+            echo "No APK produced" >&2
+            exit 1
+          fi
+          echo "path=$APK" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: localmind-android-debug
+          path: ${{ steps.apk.outputs.path }}
+
+      - name: Attach APK to GitHub Release
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          DEST="LocalMind_${TAG}_android-debug.apk"
+          cp "${{ steps.apk.outputs.path }}" "$DEST"
+          for i in 1 2 3 4 5; do
+            if gh release upload "$TAG" "$DEST" --clobber; then
+              exit 0
+            fi
+            echo "Release not ready yet, retrying in 10s ($i/5)..."
+            sleep 10
+          done
+          echo "Failed to upload APK to release $TAG" >&2
+          exit 1

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ LocalMind is a desktop app that runs open-source language models locally and exp
 |------|-------------|
 | ![LocalMind chat view](assets/screenshots/home_page.png) | ![LocalMind marketplace](assets/screenshots/marketplace.png) |
 
+## Install
+
+Grab a prebuilt installer from the [Releases page](https://github.com/s-suryakiran/LocalMind/releases) — no toolchain required:
+
+| Platform | File |
+|---|---|
+| Windows | `LocalMind_<version>_x64-setup.exe` (NSIS installer) |
+| macOS (Apple Silicon) | `LocalMind_<version>_aarch64.dmg` |
+| Linux | `localmind_<version>_amd64.deb` / `LocalMind_<version>_amd64.AppImage` |
+| Android (preview) | `LocalMind_<version>_android-debug.apk` |
+
+Or [build from source](#quickstart) if you'd rather hack on it.
+
 ## Quickstart
 
 ### Prerequisites

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["nsis", "app", "dmg", "deb", "appimage"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## What changed and why

Closes #5. End users currently have to clone the repo and set up a full dev toolchain (Rust + Node + VS Build Tools) just to install LocalMind. This adds a GitHub Actions release workflow that produces platform-native installers (`.exe`, `.dmg`, `.deb`, `.AppImage`, `.apk`) and attaches them to GitHub Releases — no toolchain required for end users. The `.exe` is built via Tauri's built-in NSIS bundler (no PyInstaller/Inno Setup needed since LocalMind is a Tauri app, not a Python app).

## How to test

1. Pull this branch and push a throwaway tag: `git tag v0.0.0-test.1 && git push origin v0.0.0-test.1`
2. Watch the **Actions** tab — the `Release` workflow should start with 4 parallel jobs (3 desktop + Android). Expected runtime ~12 min.
3. After all jobs go green, visit https://github.com/s-suryakiran/LocalMind/releases — a draft release `LocalMind v0.0.0-test.1` should exist with 5 installers attached: `*-setup.exe`, `*.dmg`, `*.deb`, `*.AppImage`, `*-android-debug.apk`. Clean up with `gh release delete v0.0.0-test.1 --cleanup-tag --yes`.

I ran exactly this on my fork — full run green in 12m 15s: https://github.com/kavya-sureshkumar/LocalMind/actions/runs/25034035350

## Checklist

- [x] `npx tsc --noEmit` passes (no TS code touched; verified green by the existing CI workflow on this branch)
- [x] `npm run build` succeeds (verified locally; full `npm run tauri build` produced a 9.3 MB `.app` + 5.4 MB `.dmg`)
- [x] `cargo fmt --all -- --check` passes (no Rust code touched)
- [x] `cargo clippy --all-targets -- -D warnings` passes (no Rust code touched)
- [x] Manually tested on macOS (local `tauri build` produces `.dmg` + `.app`; full Win/Mac/Linux/Android matrix verified by pushing a test tag through the new workflow on my fork — see link above)
- [x] Docs / README updated — added `## Install` section above Quickstart with a download table per platform
- [x] No new dependencies added

## Screenshots / recordings

N/A — no UI changes. The new draft Release page on my fork looks like:

> **LocalMind v0.0.0-test.2** *(Draft)*
>
> **Downloads**
> - Windows: `LocalMind_*_x64-setup.exe`
> - macOS: `LocalMind_*.dmg`
> - Linux: `localmind_*_amd64.deb` / `LocalMind_*_amd64.AppImage`
> - Android: `LocalMind_*_android-debug.apk` (tech preview)
>
> *8 assets attached*

## Related issues

Closes #5

---