### PR TITLE
Feature/synapse workers phase2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix",
  "slab",
  "windows-sys 0.61.2",
@@ -1250,6 +1250,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1792,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,7 +1929,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2060,6 +2082,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2365,7 +2397,9 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "futures-util",
+ "hostname",
  "local-ip-address",
+ "mdns-sd",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2481,6 +2515,19 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "mdns-sd"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+dependencies = [
+ "flume",
+ "if-addrs",
+ "log",
+ "polling 2.8.0",
+ "socket2 0.5.10",
+]
 
 [[package]]
 name = "memchr"
@@ -3154,6 +3201,22 @@ dependencies = [
 
 [[package]]
 name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
@@ -3318,7 +3381,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3355,7 +3418,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4190,6 +4253,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4244,6 +4317,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -4923,7 +5005,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,8 @@ dirs = "5"
 sysinfo = "0.30"
 local-ip-address = "0.6"
 zip = "2"
+mdns-sd = "0.11"
+hostname = "0.4"
 
 [profile.release]
 lto = true

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -169,8 +169,99 @@ pub async fn ensure_llama_server(app: &AppHandle) -> Result<PathBuf> {
         ));
     }
 
+    // Windows + CUDA: llama.cpp's CUDA binary ships separately from its CUDA
+    // runtime DLLs (`cudart64_*.dll`, `cublas64_*.dll`). Without them next to
+    // ggml-cuda.dll, LoadLibrary silently fails and llama.cpp falls back to
+    // CPU — the user sees their GPU sitting idle while their CPU pegs at 100%.
+    // We pull the matching `cudart-*.zip` from the same release and unpack it
+    // alongside.
+    if matches!(hw.accelerator, Accelerator::Nvidia { .. }) && hw.os == "windows" {
+        if let Err(e) = ensure_cuda_runtime(app, &client, assets, &target_dir).await {
+            // Best-effort — log but don't fail the install. The user gets a
+            // working CPU fallback either way; without this hint they'd just
+            // wonder why their GPU is idle.
+            emit(
+                app,
+                "warning",
+                0,
+                0,
+                &format!("CUDA runtime fetch failed (worker will use CPU only): {e}"),
+            );
+        }
+    }
+
     emit(app, "ready", total, total, "llama.cpp ready");
     Ok(path)
+}
+
+/// Pull the cudart-* sibling archive from the same llama.cpp release and
+/// unzip it next to llama-server.exe / rpc-server.exe. The release exposes
+/// archives named like `cudart-llama-bin-win-cu12.4-x64.zip` — pick the one
+/// whose CUDA version matches the binary archive we already grabbed.
+async fn ensure_cuda_runtime(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    assets: &[serde_json::Value],
+    target_dir: &Path,
+) -> Result<()> {
+    // If cudart64_*.dll already sits next to our binaries, we're done.
+    if let Ok(read) = std::fs::read_dir(target_dir) {
+        for e in read.flatten() {
+            if let Some(name) = e.file_name().to_str() {
+                let lower = name.to_ascii_lowercase();
+                if lower.starts_with("cudart64_") && lower.ends_with(".dll") {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    let asset = assets
+        .iter()
+        .find(|a| {
+            let name = a["name"].as_str().unwrap_or("").to_ascii_lowercase();
+            name.starts_with("cudart-") && name.contains("win") && name.ends_with(".zip")
+        })
+        .ok_or_else(|| anyhow!("no cudart-* asset in release"))?;
+
+    let url = asset["browser_download_url"]
+        .as_str()
+        .ok_or_else(|| anyhow!("missing cudart download url"))?;
+    let total = asset["size"].as_u64().unwrap_or(0);
+    let name = asset["name"].as_str().unwrap_or("cudart.zip").to_string();
+
+    emit(
+        app,
+        "downloading",
+        0,
+        total,
+        &format!("Downloading {} (CUDA runtime)", name),
+    );
+
+    let mut response = client.get(url).send().await?.error_for_status()?;
+    let mut downloaded: u64 = 0;
+    let tmp = target_dir.join(&name);
+    let mut file = tokio::fs::File::create(&tmp).await?;
+    use tokio::io::AsyncWriteExt;
+    while let Some(chunk) = response.chunk().await? {
+        file.write_all(&chunk).await?;
+        downloaded += chunk.len() as u64;
+        if downloaded % (1024 * 1024) < chunk.len() as u64 {
+            emit(
+                app,
+                "downloading",
+                downloaded,
+                total,
+                "Downloading CUDA runtime",
+            );
+        }
+    }
+    file.flush().await?;
+    drop(file);
+
+    extract_zip(&tmp, target_dir)?;
+    let _ = std::fs::remove_file(&tmp);
+    Ok(())
 }
 
 fn pick_llama_asset<'a>(

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -181,7 +181,9 @@ pub async fn ensure_llama_server(app: &AppHandle) -> Result<PathBuf> {
         // sibling cudart-*.zip exactly. Mismatched versions silently fail at
         // LoadLibrary time.
         let cuda_version = extract_cuda_version(&name);
-        if let Err(e) = ensure_cuda_runtime(app, &client, assets, &target_dir, cuda_version.as_deref()).await {
+        if let Err(e) =
+            ensure_cuda_runtime(app, &client, assets, &target_dir, cuda_version.as_deref()).await
+        {
             // Best-effort — log but don't fail the install. The user gets a
             // working CPU fallback either way; without this hint they'd just
             // wonder why their GPU is idle.

--- a/src-tauri/src/binaries.rs
+++ b/src-tauri/src/binaries.rs
@@ -176,7 +176,12 @@ pub async fn ensure_llama_server(app: &AppHandle) -> Result<PathBuf> {
     // We pull the matching `cudart-*.zip` from the same release and unpack it
     // alongside.
     if matches!(hw.accelerator, Accelerator::Nvidia { .. }) && hw.os == "windows" {
-        if let Err(e) = ensure_cuda_runtime(app, &client, assets, &target_dir).await {
+        // Pull the CUDA version out of the binary archive name (e.g. "13.1"
+        // from "llama-b8958-bin-win-cuda-13.1-x64.zip") so we can match the
+        // sibling cudart-*.zip exactly. Mismatched versions silently fail at
+        // LoadLibrary time.
+        let cuda_version = extract_cuda_version(&name);
+        if let Err(e) = ensure_cuda_runtime(app, &client, assets, &target_dir, cuda_version.as_deref()).await {
             // Best-effort — log but don't fail the install. The user gets a
             // working CPU fallback either way; without this hint they'd just
             // wonder why their GPU is idle.
@@ -203,6 +208,7 @@ async fn ensure_cuda_runtime(
     client: &reqwest::Client,
     assets: &[serde_json::Value],
     target_dir: &Path,
+    cuda_version: Option<&str>,
 ) -> Result<()> {
     // If cudart64_*.dll already sits next to our binaries, we're done.
     if let Ok(read) = std::fs::read_dir(target_dir) {
@@ -216,13 +222,39 @@ async fn ensure_cuda_runtime(
         }
     }
 
-    let asset = assets
+    // Prefer the cudart whose CUDA version matches the binaries we just
+    // downloaded. Fall back to the highest-numbered cudart if we couldn't
+    // parse a version. Mismatch (e.g. cu12.4 binaries with cu13.1 cudart)
+    // can superficially "load" but produce confusing init failures.
+    let cudart_candidates: Vec<&serde_json::Value> = assets
         .iter()
-        .find(|a| {
+        .filter(|a| {
             let name = a["name"].as_str().unwrap_or("").to_ascii_lowercase();
             name.starts_with("cudart-") && name.contains("win") && name.ends_with(".zip")
         })
-        .ok_or_else(|| anyhow!("no cudart-* asset in release"))?;
+        .collect();
+
+    let asset = if let Some(v) = cuda_version {
+        cudart_candidates
+            .iter()
+            .find(|a| {
+                a["name"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_ascii_lowercase()
+                    .contains(&format!("cuda-{v}"))
+            })
+            .copied()
+    } else {
+        None
+    }
+    .or_else(|| {
+        cudart_candidates
+            .iter()
+            .max_by_key(|a| a["name"].as_str().unwrap_or("").to_string())
+            .copied()
+    })
+    .ok_or_else(|| anyhow!("no cudart-* asset in release"))?;
 
     let url = asset["browser_download_url"]
         .as_str()
@@ -262,6 +294,24 @@ async fn ensure_cuda_runtime(
     extract_zip(&tmp, target_dir)?;
     let _ = std::fs::remove_file(&tmp);
     Ok(())
+}
+
+/// Pull the `MAJOR.MINOR` CUDA version out of a llama.cpp asset name like
+/// `llama-b8958-bin-win-cuda-13.1-x64.zip`. Returns `None` if the substring
+/// after `cuda-` doesn't look like a version (defensive for future renames).
+fn extract_cuda_version(asset_name: &str) -> Option<String> {
+    let lower = asset_name.to_ascii_lowercase();
+    let after = lower.split("cuda-").nth(1)?;
+    // Take chars up to the next non-version separator.
+    let v: String = after
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    if v.is_empty() || !v.contains('.') {
+        None
+    } else {
+        Some(v)
+    }
 }
 
 fn pick_llama_asset<'a>(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use rag::{Document, RagState, RetrievedChunk};
 use sd::{SdImage, SdRequest, SdState};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use synapse::{SynapseState, SynapseWorkerStatus};
+use synapse::{SynapsePeer, SynapseState, SynapseWorkerStatus};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 struct AppStateHolder {
@@ -248,6 +248,26 @@ async fn synapse_worker_status(
     Ok(state.synapse.status().await)
 }
 
+#[tauri::command]
+async fn restart_synapse_worker(
+    app: AppHandle,
+    state: State<'_, Arc<AppStateHolder>>,
+    port: Option<u16>,
+) -> Result<SynapseWorkerStatus, String> {
+    state
+        .synapse
+        .restart_worker(&app, port)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn synapse_list_peers(
+    state: State<'_, Arc<AppStateHolder>>,
+) -> Result<Vec<SynapsePeer>, String> {
+    Ok(state.synapse.list_peers().await)
+}
+
 fn generate_pin() -> String {
     let raw = uuid::Uuid::new_v4().as_u128();
     format!("{:06}", (raw % 1_000_000) as u32)
@@ -284,6 +304,8 @@ pub fn run() {
             let llama2 = llama.clone();
             let pin2 = pin.clone();
             let tokens2 = tokens.clone();
+            let synapse2 = synapse.clone();
+            let handle_for_discovery = handle.clone();
             tauri::async_runtime::spawn(async move {
                 let resource_dir = handle.path().resource_dir().ok();
                 let static_dir = resource_dir.map(|d| d.join("dist")).filter(|p| p.exists());
@@ -295,6 +317,14 @@ pub fn run() {
                     Err(e) => {
                         eprintln!("LAN server failed: {e}");
                     }
+                }
+            });
+            // Kick off mDNS browsing immediately so the Synapse page sees
+            // peers as soon as it mounts, without each `useEffect` having to
+            // wait for the daemon to spin up.
+            tauri::async_runtime::spawn(async move {
+                if let Err(e) = synapse2.start_discovery(&handle_for_discovery).await {
+                    eprintln!("synapse discovery failed: {e}");
                 }
             });
             Ok(())
@@ -323,6 +353,8 @@ pub fn run() {
             start_synapse_worker,
             stop_synapse_worker,
             synapse_worker_status,
+            restart_synapse_worker,
+            synapse_list_peers,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/synapse.rs
+++ b/src-tauri/src/synapse.rs
@@ -1,11 +1,16 @@
-// Phase 1 Synapse: each machine can run an `rpc-server` child process that
-// llama.cpp on a remote host reaches via `--rpc host:port`. Together the
-// machines form a pipeline-parallel inference cluster. Discovery, pairing, and
-// auto-split come in later phases — for now we just expose start/stop/status
-// for the worker, and let the host paste worker addresses manually.
+// Phase 2 Synapse: each machine can run an `rpc-server` child process that
+// llama.cpp on a remote host reaches via `--rpc host:port`. On top of Phase 1's
+// manual start/stop, we now also:
+//   - advertise the worker on the LAN via mDNS (`_localmind-synapse._tcp`)
+//   - browse for other workers, emitting peer add/remove events to the UI
+//   - expose a `restart_worker` so the host can flush worker VRAM on demand
+//
+// Auth + smart layer split + tok/s telemetry come in Phase 3.
 use crate::{binaries, config};
 use anyhow::{anyhow, Result};
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
@@ -14,6 +19,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
 pub const DEFAULT_WORKER_PORT: u16 = 50052;
+const SERVICE_TYPE: &str = "_localmind-synapse._tcp.local.";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -23,13 +29,34 @@ pub struct SynapseWorkerStatus {
     pub pid: Option<u32>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SynapsePeer {
+    /// Stable mDNS instance name — used as the dedupe key.
+    pub id: String,
+    /// Human-friendly hostname (whatever the worker advertised).
+    pub hostname: String,
+    /// First resolvable address — usually the LAN IPv4 we want.
+    pub address: String,
+    pub port: u16,
+    /// `address:port`, the exact string the host appends to `--rpc`.
+    pub endpoint: String,
+}
+
 struct WorkerHandle {
     child: Option<Child>,
     port: u16,
+    /// Owns the mDNS advertisement; dropping unregisters automatically.
+    advertised: Option<ServiceInfo>,
 }
 
 pub struct SynapseState {
     worker: Mutex<WorkerHandle>,
+    /// Single shared mDNS daemon (advertise + browse share one socket).
+    daemon: Mutex<Option<ServiceDaemon>>,
+    /// Peers we've seen, keyed by mDNS instance name. Cached so the UI can
+    /// re-render on demand without waiting for the next browse tick.
+    peers: Mutex<HashMap<String, SynapsePeer>>,
 }
 
 impl SynapseState {
@@ -38,7 +65,10 @@ impl SynapseState {
             worker: Mutex::new(WorkerHandle {
                 child: None,
                 port: DEFAULT_WORKER_PORT,
+                advertised: None,
             }),
+            daemon: Mutex::new(None),
+            peers: Mutex::new(HashMap::new()),
         })
     }
 
@@ -51,10 +81,20 @@ impl SynapseState {
         }
     }
 
+    pub async fn list_peers(&self) -> Vec<SynapsePeer> {
+        self.peers.lock().await.values().cloned().collect()
+    }
+
     pub async fn stop_worker(&self) -> Result<()> {
         let mut w = self.worker.lock().await;
         if let Some(mut c) = w.child.take() {
             let _ = c.kill().await;
+            let _ = c.wait().await;
+        }
+        if let Some(info) = w.advertised.take() {
+            if let Some(d) = self.daemon.lock().await.as_ref() {
+                let _ = d.unregister(info.get_fullname());
+            }
         }
         Ok(())
     }
@@ -83,7 +123,7 @@ impl SynapseState {
 
         // Bind to 0.0.0.0 so other machines on the LAN can connect; the host
         // typed our address into its workers field. There's no auth on the RPC
-        // wire (Phase 2 will fix that with an auth shim) — only run worker
+        // wire (Phase 3 will fix that with an auth shim) — only run worker
         // mode on networks you control.
         let mut cmd = Command::new(&binary);
         cmd.arg("-H").arg("0.0.0.0");
@@ -96,15 +136,173 @@ impl SynapseState {
             .map_err(|e| anyhow!("failed to spawn rpc-server: {e}"))?;
         pipe_output(app, &mut child);
 
+        // Advertise on mDNS so the host's Synapse page picks us up automatically.
+        // Best-effort: if advertising fails (e.g. no multicast on this NIC) the
+        // worker still works, the host just has to type the IP manually.
+        let advertised = match self.advertise(port).await {
+            Ok(info) => Some(info),
+            Err(e) => {
+                eprintln!("synapse: mDNS advertise failed: {e}");
+                None
+            }
+        };
+
         {
             let mut w = self.worker.lock().await;
             w.child = Some(child);
             w.port = port;
+            w.advertised = advertised;
         }
 
         let _ = app.emit("synapse:ready", serde_json::json!({ "port": port }));
 
         Ok(self.status().await)
+    }
+
+    /// Stop + start in one call so the worker frees VRAM and re-advertises.
+    /// Useful when a previous host disconnected mid-inference and llama.cpp
+    /// left buffers allocated.
+    pub async fn restart_worker(
+        &self,
+        app: &AppHandle,
+        port: Option<u16>,
+    ) -> Result<SynapseWorkerStatus> {
+        // If no port given, reuse the one we were last running on.
+        let port = match port {
+            Some(p) => Some(p),
+            None => Some(self.worker.lock().await.port),
+        };
+        self.start_worker(app, port).await
+    }
+
+    /// Start browsing for `_localmind-synapse._tcp` peers. Idempotent — calling
+    /// twice keeps the same daemon. Emits `synapse:peer-added` /
+    /// `synapse:peer-removed` events as the LAN view changes.
+    pub async fn start_discovery(self: &Arc<Self>, app: &AppHandle) -> Result<()> {
+        let daemon = {
+            let mut guard = self.daemon.lock().await;
+            if guard.is_none() {
+                *guard = Some(ServiceDaemon::new().map_err(|e| anyhow!("mdns daemon: {e}"))?);
+            }
+            guard.as_ref().unwrap().clone()
+        };
+
+        let receiver = daemon
+            .browse(SERVICE_TYPE)
+            .map_err(|e| anyhow!("mdns browse: {e}"))?;
+        let app = app.clone();
+        let me = self.clone();
+        tokio::spawn(async move {
+            // mdns-sd's receiver is a flume channel; recv_async is awaitable.
+            while let Ok(event) = receiver.recv_async().await {
+                match event {
+                    ServiceEvent::ServiceResolved(info) => {
+                        let id = info.get_fullname().to_string();
+
+                        // Skip our own advertisement — nothing useful about
+                        // adding ourselves to our own peer list.
+                        let own_fullname = me
+                            .worker
+                            .lock()
+                            .await
+                            .advertised
+                            .as_ref()
+                            .map(|a| a.get_fullname().to_string());
+                        if own_fullname.as_deref() == Some(id.as_str()) {
+                            continue;
+                        }
+
+                        let port = info.get_port();
+                        let address = info
+                            .get_addresses()
+                            .iter()
+                            .filter(|a| a.is_ipv4())
+                            .map(|a| a.to_string())
+                            .next()
+                            .unwrap_or_else(|| {
+                                info.get_addresses()
+                                    .iter()
+                                    .map(|a| a.to_string())
+                                    .next()
+                                    .unwrap_or_default()
+                            });
+                        if address.is_empty() {
+                            continue;
+                        }
+                        let hostname = info
+                            .get_property_val_str("hostname")
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|| info.get_hostname().to_string());
+                        let endpoint = format!("{}:{}", address, port);
+                        let peer = SynapsePeer {
+                            id: id.clone(),
+                            hostname,
+                            address,
+                            port,
+                            endpoint,
+                        };
+                        me.peers.lock().await.insert(id, peer.clone());
+                        let _ = app.emit("synapse:peer-added", &peer);
+                    }
+                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                        let removed = me.peers.lock().await.remove(&fullname).is_some();
+                        if removed {
+                            let _ = app.emit(
+                                "synapse:peer-removed",
+                                serde_json::json!({ "id": fullname }),
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn advertise(&self, port: u16) -> Result<ServiceInfo> {
+        // Spin up the daemon if start_discovery hasn't been called yet.
+        let daemon = {
+            let mut guard = self.daemon.lock().await;
+            if guard.is_none() {
+                *guard = Some(ServiceDaemon::new().map_err(|e| anyhow!("mdns daemon: {e}"))?);
+            }
+            guard.as_ref().unwrap().clone()
+        };
+
+        let host = hostname::get()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "localmind".to_string());
+        let instance = format!("{}-{}", host, port);
+        // mdns-sd needs a hostname ending in `.local.`; pick something stable
+        // per machine. The `hostname` crate gives us a sensible default.
+        let mdns_host = format!("{}.local.", host);
+
+        let ip = local_ip_address::local_ip()
+            .map(|ip| ip.to_string())
+            .map_err(|e| anyhow!("local ip: {e}"))?;
+
+        let mut props: HashMap<String, String> = HashMap::new();
+        props.insert("hostname".to_string(), host.clone());
+        props.insert("version".to_string(), env!("CARGO_PKG_VERSION").to_string());
+        props.insert("kind".to_string(), "rpc-server".to_string());
+
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance,
+            &mdns_host,
+            ip.as_str(),
+            port,
+            Some(props),
+        )
+        .map_err(|e| anyhow!("mdns service info: {e}"))?;
+
+        daemon
+            .register(info.clone())
+            .map_err(|e| anyhow!("mdns register: {e}"))?;
+        Ok(info)
     }
 }
 

--- a/src-tauri/src/synapse.rs
+++ b/src-tauri/src/synapse.rs
@@ -137,12 +137,28 @@ impl SynapseState {
         pipe_output(app, &mut child);
 
         // Advertise on mDNS so the host's Synapse page picks us up automatically.
-        // Best-effort: if advertising fails (e.g. no multicast on this NIC) the
-        // worker still works, the host just has to type the IP manually.
+        // Best-effort: if advertising fails (e.g. no multicast on this NIC, or
+        // hostname has chars mdns-sd refuses) the worker still works, the host
+        // just has to type the IP manually. Surface the failure as a synapse:log
+        // line so the UI can show *why* discovery isn't happening.
         let advertised = match self.advertise(port).await {
-            Ok(info) => Some(info),
+            Ok(info) => {
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({
+                        "stream": "stdout",
+                        "line": format!("mDNS advertise OK: {}", info.get_fullname()),
+                    }),
+                );
+                Some(info)
+            }
             Err(e) => {
-                eprintln!("synapse: mDNS advertise failed: {e}");
+                let msg = format!("mDNS advertise failed: {e}");
+                eprintln!("synapse: {msg}");
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({ "stream": "stderr", "line": msg }),
+                );
                 None
             }
         };
@@ -271,21 +287,32 @@ impl SynapseState {
             guard.as_ref().unwrap().clone()
         };
 
-        let host = hostname::get()
+        // Real hostname for the TXT record (UI display) — may contain spaces,
+        // underscores, etc. Windows in particular often has hostnames mdns-sd's
+        // strict validator rejects.
+        let raw_host = hostname::get()
             .ok()
             .and_then(|h| h.into_string().ok())
             .unwrap_or_else(|| "localmind".to_string());
-        let instance = format!("{}-{}", host, port);
-        // mdns-sd needs a hostname ending in `.local.`; pick something stable
-        // per machine. The `hostname` crate gives us a sensible default.
-        let mdns_host = format!("{}.local.", host);
+
+        // Sanitized hostname for the actual mDNS record: ASCII alnum + hyphen
+        // only, falls back to `localmind` if everything was stripped. RFC 1123
+        // labels also can't start/end with a hyphen, so we trim those too.
+        let sanitized = sanitize_dns_label(&raw_host);
+        let dns_host = if sanitized.is_empty() {
+            "localmind".to_string()
+        } else {
+            sanitized
+        };
+        let instance = format!("{}-{}", dns_host, port);
+        let mdns_host = format!("{}.local.", dns_host);
 
         let ip = local_ip_address::local_ip()
             .map(|ip| ip.to_string())
             .map_err(|e| anyhow!("local ip: {e}"))?;
 
         let mut props: HashMap<String, String> = HashMap::new();
-        props.insert("hostname".to_string(), host.clone());
+        props.insert("hostname".to_string(), raw_host.clone());
         props.insert("version".to_string(), env!("CARGO_PKG_VERSION").to_string());
         props.insert("kind".to_string(), "rpc-server".to_string());
 
@@ -304,6 +331,23 @@ impl SynapseState {
             .map_err(|e| anyhow!("mdns register: {e}"))?;
         Ok(info)
     }
+}
+
+/// Coerce an arbitrary hostname into a valid DNS label per RFC 1123:
+/// ASCII letters, digits, and hyphens, no leading/trailing hyphen. Windows
+/// hostnames may contain underscores or spaces which mdns-sd rejects.
+fn sanitize_dns_label(input: &str) -> String {
+    let cleaned: String = input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    cleaned.trim_matches('-').to_string()
 }
 
 fn pipe_output(app: &AppHandle, child: &mut Child) {

--- a/src-tauri/src/synapse.rs
+++ b/src-tauri/src/synapse.rs
@@ -9,17 +9,40 @@
 use crate::{binaries, config};
 use anyhow::{anyhow, Result};
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter};
 use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::net::UdpSocket;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 pub const DEFAULT_WORKER_PORT: u16 = 50052;
 const SERVICE_TYPE: &str = "_localmind-synapse._tcp.local.";
+
+// UDP broadcast beacon — runs alongside mDNS as a fallback for networks
+// where multicast is blocked (very common on Wi-Fi). Worker sends every
+// BEACON_INTERVAL; host listens on BEACON_PORT and ages peers out after
+// PEER_TTL of silence.
+const BEACON_PORT: u16 = 50053;
+const BEACON_INTERVAL: Duration = Duration::from_secs(3);
+const PEER_TTL: Duration = Duration::from_secs(15);
+const BEACON_MAGIC: &str = "localmind-synapse/1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BeaconPayload {
+    /// Magic string so we can ignore stray UDP traffic on this port.
+    magic: String,
+    /// Stable per-machine ID so the host can dedupe.
+    id: String,
+    hostname: String,
+    port: u16,
+    version: String,
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,6 +71,16 @@ struct WorkerHandle {
     port: u16,
     /// Owns the mDNS advertisement; dropping unregisters automatically.
     advertised: Option<ServiceInfo>,
+    /// Beacon broadcaster task; cancelled when the worker stops.
+    beacon: Option<JoinHandle<()>>,
+}
+
+/// Beacon entry tracked on the host side. We only emit a peer-added event
+/// when we first hear from a worker, then refresh `last_seen` on each ping.
+/// A janitor task removes entries that have gone silent for PEER_TTL.
+struct BeaconEntry {
+    peer: SynapsePeer,
+    last_seen: Instant,
 }
 
 pub struct SynapseState {
@@ -57,6 +90,10 @@ pub struct SynapseState {
     /// Peers we've seen, keyed by mDNS instance name. Cached so the UI can
     /// re-render on demand without waiting for the next browse tick.
     peers: Mutex<HashMap<String, SynapsePeer>>,
+    /// UDP-beacon peers, keyed by beacon `id`. Separate map so the janitor
+    /// can age them out without touching mDNS-discovered ones (mDNS does
+    /// its own TTL via ServiceRemoved events).
+    beacons: Mutex<HashMap<String, BeaconEntry>>,
 }
 
 impl SynapseState {
@@ -66,9 +103,11 @@ impl SynapseState {
                 child: None,
                 port: DEFAULT_WORKER_PORT,
                 advertised: None,
+                beacon: None,
             }),
             daemon: Mutex::new(None),
             peers: Mutex::new(HashMap::new()),
+            beacons: Mutex::new(HashMap::new()),
         })
     }
 
@@ -82,7 +121,18 @@ impl SynapseState {
     }
 
     pub async fn list_peers(&self) -> Vec<SynapsePeer> {
-        self.peers.lock().await.values().cloned().collect()
+        // Merge mDNS-discovered peers with UDP-beacon peers, keyed by endpoint
+        // so the same worker reachable via both routes shows up only once.
+        let mut by_endpoint: HashMap<String, SynapsePeer> = HashMap::new();
+        for p in self.peers.lock().await.values() {
+            by_endpoint.insert(p.endpoint.clone(), p.clone());
+        }
+        for entry in self.beacons.lock().await.values() {
+            by_endpoint
+                .entry(entry.peer.endpoint.clone())
+                .or_insert_with(|| entry.peer.clone());
+        }
+        by_endpoint.into_values().collect()
     }
 
     pub async fn stop_worker(&self) -> Result<()> {
@@ -90,6 +140,9 @@ impl SynapseState {
         if let Some(mut c) = w.child.take() {
             let _ = c.kill().await;
             let _ = c.wait().await;
+        }
+        if let Some(handle) = w.beacon.take() {
+            handle.abort();
         }
         if let Some(info) = w.advertised.take() {
             if let Some(d) = self.daemon.lock().await.as_ref() {
@@ -174,11 +227,30 @@ impl SynapseState {
             }
         };
 
+        // Spawn the UDP-broadcast beacon. This runs in parallel with mDNS as a
+        // fallback for networks where multicast is filtered (Wi-Fi APs with
+        // client isolation, Windows machines on Public profile, corp Wi-Fi…).
+        // Beacon uses 255.255.255.255, which is far more permissive on most
+        // networks than 224.0.0.251 multicast.
+        let beacon_handle = match spawn_beacon(app.clone(), port).await {
+            Ok(h) => Some(h),
+            Err(e) => {
+                let msg = format!("UDP beacon failed: {e}");
+                eprintln!("synapse: {msg}");
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({ "stream": "stderr", "line": msg }),
+                );
+                None
+            }
+        };
+
         {
             let mut w = self.worker.lock().await;
             w.child = Some(child);
             w.port = port;
             w.advertised = advertised;
+            w.beacon = beacon_handle;
         }
 
         let _ = app.emit("synapse:ready", serde_json::json!({ "port": port }));
@@ -217,9 +289,12 @@ impl SynapseState {
         let receiver = daemon
             .browse(SERVICE_TYPE)
             .map_err(|e| anyhow!("mdns browse: {e}"))?;
-        let app = app.clone();
+        // Clone for the mDNS browse task; the original `app` is reused below
+        // for the beacon listener + janitor.
+        let app_mdns = app.clone();
         let me = self.clone();
         tokio::spawn(async move {
+            let app = app_mdns;
             // mdns-sd's receiver is a flume channel; recv_async is awaitable.
             while let Ok(event) = receiver.recv_async().await {
                 match event {
@@ -284,6 +359,40 @@ impl SynapseState {
                 }
             }
         });
+
+        // UDP-beacon listener. Runs alongside mDNS so peers from either route
+        // both surface in the UI (deduped by endpoint in `list_peers`). Bound
+        // to 0.0.0.0:50053 — no special firewall coordination needed if the
+        // user already let LocalMind through, since this is the same exe.
+        match UdpSocket::bind(("0.0.0.0", BEACON_PORT)).await {
+            Ok(sock) => {
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({
+                        "stream": "stdout",
+                        "line": format!("UDP beacon listener on 0.0.0.0:{BEACON_PORT}"),
+                    }),
+                );
+                let app_l = app.clone();
+                let me_l = self.clone();
+                tokio::spawn(async move { run_beacon_listener(me_l, app_l, sock).await });
+
+                // Janitor: drop beacon entries after PEER_TTL of silence so a
+                // worker that vanishes (machine slept, network dropped, app
+                // killed) doesn't linger forever in the host's peer list.
+                let app_j = app.clone();
+                let me_j = self.clone();
+                tokio::spawn(async move { run_beacon_janitor(me_j, app_j).await });
+            }
+            Err(e) => {
+                let msg = format!("UDP beacon listener failed: {e}");
+                eprintln!("synapse: {msg}");
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({ "stream": "stderr", "line": msg }),
+                );
+            }
+        }
 
         Ok(())
     }
@@ -359,6 +468,147 @@ fn sanitize_dns_label(input: &str) -> String {
         })
         .collect();
     cleaned.trim_matches('-').to_string()
+}
+
+/// Spawn the UDP-broadcast beacon for this worker. Sends a small JSON packet
+/// to 255.255.255.255:BEACON_PORT every BEACON_INTERVAL. Returns a JoinHandle
+/// the caller stores so it can `.abort()` on stop_worker.
+async fn spawn_beacon(app: AppHandle, port: u16) -> Result<JoinHandle<()>> {
+    let raw_host = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "localmind".to_string());
+    let id = format!("beacon:{}-{}", sanitize_dns_label(&raw_host), port);
+    let payload = BeaconPayload {
+        magic: BEACON_MAGIC.to_string(),
+        id,
+        hostname: raw_host,
+        port,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let bytes = serde_json::to_vec(&payload).map_err(|e| anyhow!("beacon serialize: {e}"))?;
+
+    // Bind to an ephemeral port; we only ever send. Setting broadcast on the
+    // socket lets us hit the limited-broadcast address 255.255.255.255.
+    let sock = UdpSocket::bind(("0.0.0.0", 0))
+        .await
+        .map_err(|e| anyhow!("beacon bind: {e}"))?;
+    sock.set_broadcast(true)
+        .map_err(|e| anyhow!("beacon set_broadcast: {e}"))?;
+
+    let _ = app.emit(
+        "synapse:log",
+        serde_json::json!({
+            "stream": "stdout",
+            "line": format!(
+                "UDP beacon broadcasting on 255.255.255.255:{BEACON_PORT} every {}s",
+                BEACON_INTERVAL.as_secs(),
+            ),
+        }),
+    );
+
+    let handle = tokio::spawn(async move {
+        loop {
+            // Send to the limited broadcast address; routers won't forward it
+            // off the LAN, which is exactly what we want.
+            if let Err(e) = sock.send_to(&bytes, ("255.255.255.255", BEACON_PORT)).await {
+                let _ = app.emit(
+                    "synapse:log",
+                    serde_json::json!({
+                        "stream": "stderr",
+                        "line": format!("beacon send failed: {e}"),
+                    }),
+                );
+            }
+            tokio::time::sleep(BEACON_INTERVAL).await;
+        }
+    });
+    Ok(handle)
+}
+
+/// Receive UDP beacons forever. Each packet that parses cleanly and isn't from
+/// our own beacon ID becomes a peer-added (or refresh) event.
+async fn run_beacon_listener(state: Arc<SynapseState>, app: AppHandle, sock: UdpSocket) {
+    let own_id = format!(
+        "beacon:{}-{}",
+        sanitize_dns_label(
+            &hostname::get()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_else(|| "localmind".to_string())
+        ),
+        state.worker.lock().await.port
+    );
+
+    let mut buf = [0u8; 1024];
+    loop {
+        let (n, src) = match sock.recv_from(&mut buf).await {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let payload: BeaconPayload = match serde_json::from_slice(&buf[..n]) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if payload.magic != BEACON_MAGIC {
+            continue;
+        }
+        if payload.id == own_id {
+            continue;
+        }
+
+        let address = src.ip().to_string();
+        let endpoint = format!("{}:{}", address, payload.port);
+        let peer = SynapsePeer {
+            id: payload.id.clone(),
+            hostname: payload.hostname.clone(),
+            address,
+            port: payload.port,
+            endpoint,
+        };
+
+        // Insert or refresh. Only fire peer-added on first sight; refreshes
+        // are silent so the UI doesn't churn every 3s.
+        let mut beacons = state.beacons.lock().await;
+        let is_new = !beacons.contains_key(&payload.id);
+        beacons.insert(
+            payload.id.clone(),
+            BeaconEntry {
+                peer: peer.clone(),
+                last_seen: Instant::now(),
+            },
+        );
+        drop(beacons);
+        if is_new {
+            let _ = app.emit("synapse:peer-added", &peer);
+        }
+    }
+}
+
+/// Periodically prune beacon entries whose last_seen is older than PEER_TTL.
+/// Removed peers fire `synapse:peer-removed` so the UI can drop them from the
+/// list without waiting for a full refresh.
+async fn run_beacon_janitor(state: Arc<SynapseState>, app: AppHandle) {
+    let mut ticker = tokio::time::interval(Duration::from_secs(2));
+    loop {
+        ticker.tick().await;
+        let mut to_remove = Vec::new();
+        {
+            let now = Instant::now();
+            let mut beacons = state.beacons.lock().await;
+            beacons.retain(|id, entry| {
+                if now.duration_since(entry.last_seen) > PEER_TTL {
+                    to_remove.push(id.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        for id in to_remove {
+            let _ = app.emit("synapse:peer-removed", serde_json::json!({ "id": id }));
+        }
+    }
 }
 
 fn pipe_output(app: &AppHandle, child: &mut Child) {

--- a/src-tauri/src/synapse.rs
+++ b/src-tauri/src/synapse.rs
@@ -143,11 +143,22 @@ impl SynapseState {
         // line so the UI can show *why* discovery isn't happening.
         let advertised = match self.advertise(port).await {
             Ok(info) => {
+                let addrs = info
+                    .get_addresses()
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
                 let _ = app.emit(
                     "synapse:log",
                     serde_json::json!({
                         "stream": "stdout",
-                        "line": format!("mDNS advertise OK: {}", info.get_fullname()),
+                        "line": format!(
+                            "mDNS advertise OK: {} on {} (port {})",
+                            info.get_fullname(),
+                            if addrs.is_empty() { "<no addr>".to_string() } else { addrs },
+                            port,
+                        ),
                     }),
                 );
                 Some(info)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Marketplace } from "./pages/Marketplace";
 import { Models } from "./pages/Models";
 import { Knowledge } from "./pages/Knowledge";
 import { ImageGen } from "./pages/ImageGen";
+import { Synapse } from "./pages/Synapse";
 import { Settings } from "./pages/Settings";
 import { Connect } from "./pages/Connect";
 
@@ -70,6 +71,7 @@ function App() {
         {!remote && view === "models" && <Models />}
         {!remote && view === "knowledge" && <Knowledge />}
         {!remote && view === "image" && <ImageGen />}
+        {!remote && view === "synapse" && <Synapse />}
         {view === "settings" && <Settings />}
       </main>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, Store, Boxes, BookOpen, Image as ImageIcon, Settings as SettingsIcon, Plus, Trash2, X } from "lucide-react";
+import { MessageSquare, Store, Boxes, BookOpen, Image as ImageIcon, Network, Settings as SettingsIcon, Plus, Trash2, X } from "lucide-react";
 import { useApp } from "../lib/store";
 import { HardwareBadge } from "./HardwareBadge";
 import { cn } from "../lib/util";
@@ -70,6 +70,7 @@ export function Sidebar({
         {!remote && <NavItem icon={<Boxes size={15} />} label="My models" active={view === "models"} onClick={onPick(() => setView("models"))} />}
         {!remote && <NavItem icon={<BookOpen size={15} />} label="Knowledge" active={view === "knowledge"} onClick={onPick(() => setView("knowledge"))} />}
         {!remote && <NavItem icon={<ImageIcon size={15} />} label="Images" active={view === "image"} onClick={onPick(() => setView("image"))} />}
+        {!remote && <NavItem icon={<Network size={15} />} label="Synapse" active={view === "synapse"} onClick={onPick(() => setView("synapse"))} />}
         <NavItem icon={<SettingsIcon size={15} />} label="Settings" active={view === "settings"} onClick={onPick(() => setView("settings"))} />
       </nav>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   RetrievedChunk,
   SdImage,
   SdRequest,
+  SynapsePeer,
   SynapseWorkerStatus,
 } from "./types";
 
@@ -110,6 +111,9 @@ export const api = {
     invoke<SynapseWorkerStatus>("start_synapse_worker", { port }),
   stopSynapseWorker: () => invoke<void>("stop_synapse_worker"),
   synapseWorkerStatus: () => invoke<SynapseWorkerStatus>("synapse_worker_status"),
+  restartSynapseWorker: (port?: number) =>
+    invoke<SynapseWorkerStatus>("restart_synapse_worker", { port }),
+  synapseListPeers: () => invoke<SynapsePeer[]>("synapse_list_peers"),
 };
 
 export type ChatContentPart =

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -24,7 +24,7 @@ function abortChatRequest(convId: string) {
   }
 }
 
-type View = "chat" | "marketplace" | "models" | "knowledge" | "image" | "settings";
+type View = "chat" | "marketplace" | "models" | "knowledge" | "image" | "synapse" | "settings";
 
 interface AppState {
   view: View;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,15 @@ export interface SynapseWorkerStatus {
   pid: number | null;
 }
 
+export interface SynapsePeer {
+  id: string;
+  hostname: string;
+  address: string;
+  port: number;
+  /** `address:port` — paste-ready for the workers list. */
+  endpoint: string;
+}
+
 export interface ModelDownloadProgress {
   id: string;
   downloaded: number;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { Cpu, Wifi, Smartphone, Copy, Check, KeyRound, LogOut, Network, Power, Terminal, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Cpu, Wifi, Smartphone, Copy, Check, KeyRound, LogOut } from "lucide-react";
 import QRCode from "qrcode";
 import { useApp } from "../lib/store";
 import { api } from "../lib/api";
@@ -8,110 +8,19 @@ import { listen } from "../lib/api";
 import { isTauri } from "../lib/util";
 
 export function Settings() {
-  const {
-    hardware, lanUrl, connection, setConnection,
-    synapse, setSynapseWorkerEnabled, setSynapseWorkerPort, setSynapseWorkers,
-  } = useApp();
+  const { hardware, lanUrl, connection, setConnection } = useApp();
   const remote = !isTauri();
   const [engineStatus, setEngineStatus] = useState<string>("not checked");
   const [engineProgress, setEngineProgress] = useState<BinaryProgress | null>(null);
   const [copied, setCopied] = useState<"url" | "pin" | null>(null);
   const [pin, setPin] = useState<string | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
-  const [workerBusy, setWorkerBusy] = useState(false);
-  const [workerError, setWorkerError] = useState<string | null>(null);
-  // Edited as a single string so the user can type commas freely; we split on
-  // save / on every keystroke to keep the persisted store in `string[]` form.
-  const [workersText, setWorkersText] = useState(synapse.workers.join(", "));
-
-  // Synapse log panel: rolling buffer fed by `llama:log` (host's llama-server)
-  // and `synapse:log` (this machine's rpc-server when worker mode is on).
-  // We keep raw entries so the "Highlights" filter can be toggled without
-  // dropping lines, and bound the buffer at MAX_LOG_LINES to avoid leaking RAM
-  // over a long session.
-  const MAX_LOG_LINES = 400;
-  type LogEntry = { source: "llama" | "synapse"; stream: string; line: string; tag?: string };
-  const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [highlightsOnly, setHighlightsOnly] = useState(true);
-  const [autoScroll, setAutoScroll] = useState(true);
-  const logBoxRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (remote) return;
     listen<BinaryProgress>("binary:progress", (p) => setEngineProgress(p));
     api.getLanPin().then(setPin).catch(() => {});
-    // Reconcile the store toggle with whatever the backend actually has running
-    // (e.g. after a desktop restart with worker mode previously enabled).
-    api.synapseWorkerStatus()
-      .then((s) => setSynapseWorkerEnabled(s.running))
-      .catch(() => {});
-  }, [remote, setSynapseWorkerEnabled]);
-
-  // Subscribe to log streams from both llama-server and rpc-server. Both
-  // emitters live in Rust (`pipe_output` in llama.rs / synapse.rs) and emit
-  // structured JSON. The promise→fn dance is so we can `await` the unsubscribe
-  // when the component unmounts — `listen()` resolves to a fn, not an unsub.
-  useEffect(() => {
-    if (remote) return;
-    let pending: Array<() => void> = [];
-    let cancelled = false;
-
-    const append = (entry: LogEntry) => {
-      setLogs((prev) => {
-        const next = prev.concat(entry);
-        // O(1) trim at the head when we exceed the cap. We pay slice() instead
-        // of mutating in place because React needs a new reference to re-render.
-        return next.length > MAX_LOG_LINES ? next.slice(next.length - MAX_LOG_LINES) : next;
-      });
-    };
-
-    listen<{ stream: string; line: string; tag?: string }>("llama:log", (p) => {
-      append({ source: "llama", stream: p.stream, line: p.line, tag: p.tag });
-    }).then((un) => { if (cancelled) un(); else pending.push(un); });
-
-    listen<{ stream: string; line: string }>("synapse:log", (p) => {
-      append({ source: "synapse", stream: p.stream, line: p.line });
-    }).then((un) => { if (cancelled) un(); else pending.push(un); });
-
-    return () => {
-      cancelled = true;
-      pending.forEach((un) => un());
-    };
   }, [remote]);
-
-  useEffect(() => {
-    if (autoScroll && logBoxRef.current) {
-      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
-    }
-  }, [logs, autoScroll]);
-
-  async function toggleWorker(next: boolean) {
-    setWorkerBusy(true);
-    setWorkerError(null);
-    try {
-      if (next) {
-        const status = await api.startSynapseWorker(synapse.workerPort);
-        setSynapseWorkerEnabled(status.running);
-        setSynapseWorkerPort(status.port);
-      } else {
-        await api.stopSynapseWorker();
-        setSynapseWorkerEnabled(false);
-      }
-    } catch (e: any) {
-      setWorkerError(e?.message ?? String(e));
-    } finally {
-      setWorkerBusy(false);
-    }
-  }
-
-  function commitWorkersText(text: string) {
-    setWorkersText(text);
-    const parsed = text
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-    setSynapseWorkers(parsed);
-  }
 
   // Render a QR encoding {url, pin} JSON so a future scan-to-pair flow can
   // populate both fields in one tap.
@@ -244,162 +153,6 @@ export function Settings() {
           </Section>
         )}
 
-        {!remote && (
-          <Section title="Synapse — pool machines on your LAN" icon={<Network size={15} />}>
-            <p className="text-sm text-[var(--color-text-muted)] mb-4">
-              Run a model whose weights don't fit on one machine by pipeline-sharding layers across multiple
-              computers on your local Wi-Fi. <span className="text-[var(--color-text-subtle)]">Phase 1 (manual): toggle worker mode below on each helper machine, then list their addresses on the host. Wired Ethernet is strongly recommended for tokens/sec.</span>
-            </p>
-
-            <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-panel-2)] p-3 mb-4">
-              <div className="flex items-start gap-3">
-                <Power
-                  size={15}
-                  className={synapse.workerEnabled ? "text-[var(--color-success)] mt-0.5" : "text-[var(--color-text-muted)] mt-0.5"}
-                />
-                <div className="flex-1">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <div className="text-sm font-medium">Run as a Synapse worker</div>
-                      <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
-                        Spawns <code>rpc-server</code> on this machine so a host can offload layers to it.
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => toggleWorker(!synapse.workerEnabled)}
-                      disabled={workerBusy}
-                      className={`text-sm px-3 py-1.5 rounded-md border ${
-                        synapse.workerEnabled
-                          ? "bg-[var(--color-success)]/10 border-[var(--color-success)]/40 text-[var(--color-success)]"
-                          : "bg-[var(--color-panel)] border-[var(--color-border)] hover:border-[var(--color-accent)]/60"
-                      } disabled:opacity-50`}
-                    >
-                      {workerBusy ? "…" : synapse.workerEnabled ? "Stop worker" : "Start worker"}
-                    </button>
-                  </div>
-                  <div className="mt-3 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
-                    <span>Listen port:</span>
-                    <input
-                      type="number"
-                      value={synapse.workerPort}
-                      disabled={synapse.workerEnabled}
-                      onChange={(e) => setSynapseWorkerPort(parseInt(e.target.value, 10) || 50052)}
-                      className="w-20 bg-[var(--color-panel)] border border-[var(--color-border)] rounded px-2 py-0.5 text-[var(--color-text)] disabled:opacity-50"
-                    />
-                    <span className="text-[var(--color-text-subtle)]">(default 50052)</span>
-                  </div>
-                  {workerError && (
-                    <div className="mt-2 text-xs text-[var(--color-danger)]">{workerError}</div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <div>
-              <div className="text-sm font-medium mb-1">Workers (this machine is the host)</div>
-              <div className="text-xs text-[var(--color-text-muted)] mb-2">
-                Comma-separated <code>host:port</code>. Leave empty to run a model only on this machine.
-              </div>
-              <textarea
-                value={workersText}
-                onChange={(e) => commitWorkersText(e.target.value)}
-                placeholder="192.168.1.50:50052, mac-mini.local:50052"
-                rows={2}
-                className="w-full text-sm font-mono bg-[var(--color-panel-2)] border border-[var(--color-border)] rounded-md px-3 py-2 placeholder:text-[var(--color-text-subtle)]"
-              />
-              {synapse.workers.length > 0 && (
-                <div className="mt-2 text-xs text-[var(--color-text-muted)]">
-                  {synapse.workers.length} worker{synapse.workers.length === 1 ? "" : "s"} configured · applied
-                  on the next model load.
-                </div>
-              )}
-            </div>
-
-            {/* Live log panel — surfaces stdout/stderr from llama-server (host)
-                and rpc-server (worker) so users can confirm RPC is engaged.
-                "Highlights" filter narrows to lines mentioning RPC / offload /
-                buffer-size, which is what you actually want when debugging
-                whether layers landed on the worker. */}
-            <div className="mt-5">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <Terminal size={13} className="text-[var(--color-text-muted)]" />
-                  Live logs
-                  <span className="text-xs text-[var(--color-text-subtle)] font-normal">
-                    ({logs.length}/{MAX_LOG_LINES})
-                  </span>
-                </div>
-                <div className="flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
-                  <label className="flex items-center gap-1.5 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={highlightsOnly}
-                      onChange={(e) => setHighlightsOnly(e.target.checked)}
-                      className="accent-[var(--color-accent)]"
-                    />
-                    Highlights
-                  </label>
-                  <label className="flex items-center gap-1.5 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={autoScroll}
-                      onChange={(e) => setAutoScroll(e.target.checked)}
-                      className="accent-[var(--color-accent)]"
-                    />
-                    Auto-scroll
-                  </label>
-                  <button
-                    onClick={() => setLogs([])}
-                    className="flex items-center gap-1 hover:text-[var(--color-text)]"
-                    title="Clear logs"
-                  >
-                    <Trash2 size={12} />
-                    Clear
-                  </button>
-                </div>
-              </div>
-              <div
-                ref={logBoxRef}
-                className="font-mono text-[11px] leading-[1.45] bg-black/60 border border-[var(--color-border)] rounded-md p-2.5 h-[220px] overflow-y-auto"
-              >
-                {logs.length === 0 ? (
-                  <div className="text-[var(--color-text-subtle)] italic">
-                    Waiting for output… Load a model to see llama-server initialize, or start
-                    worker mode to see rpc-server output.
-                  </div>
-                ) : (
-                  logs
-                    .filter((l) => !highlightsOnly || isHighlight(l.line))
-                    .map((l, i) => (
-                      <div
-                        key={i}
-                        className={
-                          l.stream === "stderr"
-                            ? "text-[var(--color-text-muted)]"
-                            : "text-[var(--color-text)]"
-                        }
-                      >
-                        <span
-                          className={
-                            l.source === "synapse"
-                              ? "text-[var(--color-accent)]"
-                              : "text-[var(--color-success)]"
-                          }
-                        >
-                          [{l.source === "synapse" ? "rpc-server" : `llama-${l.tag ?? "server"}`}]
-                        </span>{" "}
-                        {l.line}
-                      </div>
-                    ))
-                )}
-              </div>
-              <div className="mt-1.5 text-[11px] text-[var(--color-text-subtle)]">
-                Highlights: lines mentioning <code>RPC</code>, <code>offload</code>,
-                <code> buffer size</code>, or errors — the signals that confirm a layer split actually happened.
-              </div>
-            </div>
-          </Section>
-        )}
       </div>
     </div>
   );
@@ -424,15 +177,6 @@ function Row({ k, v }: { k: string; v: string }) {
       <div className="text-right break-all">{v}</div>
     </div>
   );
-}
-
-// Pre-compiled regex for the "interesting" log lines that prove distributed
-// inference is actually engaged. Anything mentioning RPC backend registration,
-// the buffer-size table at load, layer offloading, or hard errors qualifies.
-const HIGHLIGHT_RE =
-  /\b(rpc|offload|buffer size|backend|n_layer|tensor split|error|failed|timeout)\b/i;
-function isHighlight(line: string): boolean {
-  return HIGHLIGHT_RE.test(line);
 }
 
 function describeAcc(a: any): string {

--- a/src/pages/Synapse.tsx
+++ b/src/pages/Synapse.tsx
@@ -1,0 +1,472 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Network,
+  Power,
+  Terminal,
+  Trash2,
+  RefreshCw,
+  Plus,
+  Radio,
+  Server,
+  Search,
+} from "lucide-react";
+import { useApp } from "../lib/store";
+import { api, listen } from "../lib/api";
+import type { SynapsePeer } from "../lib/types";
+import { isTauri } from "../lib/util";
+
+// Live log buffer cap. ~400 lines is enough to scrollback through a model load
+// without eating RAM during long sessions.
+const MAX_LOG_LINES = 400;
+
+type LogEntry = {
+  source: "llama" | "synapse";
+  stream: string;
+  line: string;
+  tag?: string;
+};
+
+// Pre-compiled regex for "interesting" log lines that confirm distributed
+// inference is actually engaged. Mentioned RPC backends, buffer tables, layer
+// offloads, and any errors qualify — those are the lines that prove a layer
+// split actually happened.
+const HIGHLIGHT_RE =
+  /\b(rpc|offload|buffer size|backend|n_layer|tensor split|error|failed|timeout)\b/i;
+
+export function Synapse() {
+  const remote = !isTauri();
+  const {
+    synapse,
+    setSynapseWorkerEnabled,
+    setSynapseWorkerPort,
+    setSynapseWorkers,
+  } = useApp();
+
+  const [workerBusy, setWorkerBusy] = useState(false);
+  const [workerError, setWorkerError] = useState<string | null>(null);
+  // We edit workers as a single textarea string so users can type commas/newlines
+  // freely; on commit we split into the canonical `string[]`.
+  const [workersText, setWorkersText] = useState(synapse.workers.join(", "));
+
+  // Discovered peers via mDNS. Keyed by peer.id (the mDNS instance name) so
+  // duplicates from re-resolution don't double-render.
+  const [peers, setPeers] = useState<Record<string, SynapsePeer>>({});
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [highlightsOnly, setHighlightsOnly] = useState(true);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const logBoxRef = useRef<HTMLDivElement>(null);
+
+  // Sync the worker toggle with backend reality on mount — the persisted store
+  // can drift from the actual rpc-server child if the app crashed mid-run.
+  useEffect(() => {
+    if (remote) return;
+    api.synapseWorkerStatus()
+      .then((s) => {
+        setSynapseWorkerEnabled(s.running);
+        if (s.port) setSynapseWorkerPort(s.port);
+      })
+      .catch(() => {});
+    api.synapseListPeers()
+      .then((list) => {
+        const next: Record<string, SynapsePeer> = {};
+        for (const p of list) next[p.id] = p;
+        setPeers(next);
+      })
+      .catch(() => {});
+  }, [remote, setSynapseWorkerEnabled, setSynapseWorkerPort]);
+
+  // Subscribe to mDNS peer events. The Rust side starts browsing at app boot,
+  // so we just have to hook into the stream — no `start_discovery` to call.
+  useEffect(() => {
+    if (remote) return;
+    let pending: Array<() => void> = [];
+    let cancelled = false;
+
+    listen<SynapsePeer>("synapse:peer-added", (p) => {
+      setPeers((prev) => ({ ...prev, [p.id]: p }));
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<{ id: string }>("synapse:peer-removed", (p) => {
+      setPeers((prev) => {
+        if (!(p.id in prev)) return prev;
+        const next = { ...prev };
+        delete next[p.id];
+        return next;
+      });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    return () => {
+      cancelled = true;
+      pending.forEach((un) => un());
+    };
+  }, [remote]);
+
+  // Subscribe to llama-server / rpc-server log streams. Same shape as the old
+  // Settings panel — we kept the panel here because debugging Synapse is the
+  // main reason anyone wants to see these logs.
+  useEffect(() => {
+    if (remote) return;
+    let pending: Array<() => void> = [];
+    let cancelled = false;
+
+    const append = (entry: LogEntry) => {
+      setLogs((prev) => {
+        const next = prev.concat(entry);
+        return next.length > MAX_LOG_LINES ? next.slice(next.length - MAX_LOG_LINES) : next;
+      });
+    };
+
+    listen<{ stream: string; line: string; tag?: string }>("llama:log", (p) => {
+      append({ source: "llama", stream: p.stream, line: p.line, tag: p.tag });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<{ stream: string; line: string }>("synapse:log", (p) => {
+      append({ source: "synapse", stream: p.stream, line: p.line });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    return () => {
+      cancelled = true;
+      pending.forEach((un) => un());
+    };
+  }, [remote]);
+
+  useEffect(() => {
+    if (autoScroll && logBoxRef.current) {
+      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+    }
+  }, [logs, autoScroll]);
+
+  async function toggleWorker(next: boolean) {
+    setWorkerBusy(true);
+    setWorkerError(null);
+    try {
+      if (next) {
+        const status = await api.startSynapseWorker(synapse.workerPort);
+        setSynapseWorkerEnabled(status.running);
+        setSynapseWorkerPort(status.port);
+      } else {
+        await api.stopSynapseWorker();
+        setSynapseWorkerEnabled(false);
+      }
+    } catch (e: any) {
+      setWorkerError(e?.message ?? String(e));
+    } finally {
+      setWorkerBusy(false);
+    }
+  }
+
+  // Restart the rpc-server child. Useful when a previous host disconnected
+  // mid-inference and llama.cpp left buffers allocated on the GPU — a clean
+  // restart guarantees VRAM is freed.
+  async function restartWorker() {
+    setWorkerBusy(true);
+    setWorkerError(null);
+    try {
+      const status = await api.restartSynapseWorker(synapse.workerPort);
+      setSynapseWorkerEnabled(status.running);
+      setSynapseWorkerPort(status.port);
+    } catch (e: any) {
+      setWorkerError(e?.message ?? String(e));
+    } finally {
+      setWorkerBusy(false);
+    }
+  }
+
+  function commitWorkersText(text: string) {
+    setWorkersText(text);
+    const parsed = text
+      .split(/[,\n]/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setSynapseWorkers(parsed);
+  }
+
+  // Add a discovered peer to the workers list with one click. Avoid dupes.
+  function addPeer(p: SynapsePeer) {
+    if (synapse.workers.includes(p.endpoint)) return;
+    const next = [...synapse.workers, p.endpoint];
+    setSynapseWorkers(next);
+    setWorkersText(next.join(", "));
+  }
+
+  function removeWorker(endpoint: string) {
+    const next = synapse.workers.filter((w) => w !== endpoint);
+    setSynapseWorkers(next);
+    setWorkersText(next.join(", "));
+  }
+
+  const peerList = useMemo(() => Object.values(peers), [peers]);
+  const filteredLogs = useMemo(
+    () => (highlightsOnly ? logs.filter((l) => HIGHLIGHT_RE.test(l.line)) : logs),
+    [logs, highlightsOnly],
+  );
+
+  if (remote) {
+    // Phone/PWA — Synapse is desktop-only since it spawns child processes.
+    return (
+      <div className="flex flex-col h-full items-center justify-center text-center px-6">
+        <Network size={28} className="text-[var(--color-text-muted)] mb-3" />
+        <p className="text-sm text-[var(--color-text-muted)] max-w-sm">
+          Synapse runs on the desktop host — open LocalMind on the paired Mac/PC to
+          manage workers and peers.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="px-5 py-4 border-b border-[var(--color-border-soft)]">
+        <h1 className="font-semibold text-[17px] flex items-center gap-2">
+          <Network size={16} /> Synapse
+        </h1>
+        <p className="text-[var(--color-text-muted)] text-sm">
+          Pool GPUs across LAN machines to run models that don't fit on one device.
+          Wired Ethernet recommended for tokens/sec.
+        </p>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-5 py-5 max-w-3xl">
+        {/* Worker mode card */}
+        <Section title="This machine" icon={<Server size={15} />}>
+          <div className="flex items-start gap-3">
+            <Power
+              size={15}
+              className={
+                synapse.workerEnabled
+                  ? "text-[var(--color-success)] mt-0.5"
+                  : "text-[var(--color-text-muted)] mt-0.5"
+              }
+            />
+            <div className="flex-1">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium">Run as a Synapse worker</div>
+                  <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
+                    Spawns <code>rpc-server</code> and announces this machine on the LAN
+                    via mDNS so other LocalMind hosts can find it automatically.
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {synapse.workerEnabled && (
+                    <button
+                      onClick={restartWorker}
+                      disabled={workerBusy}
+                      title="Restart worker — flushes VRAM"
+                      className="text-sm px-2.5 py-1.5 rounded-md bg-[var(--color-panel-2)] border border-[var(--color-border)] hover:border-[var(--color-accent)]/60 disabled:opacity-50"
+                    >
+                      <RefreshCw size={13} />
+                    </button>
+                  )}
+                  <button
+                    onClick={() => toggleWorker(!synapse.workerEnabled)}
+                    disabled={workerBusy}
+                    className={`text-sm px-3 py-1.5 rounded-md border ${
+                      synapse.workerEnabled
+                        ? "bg-[var(--color-success)]/10 border-[var(--color-success)]/40 text-[var(--color-success)]"
+                        : "bg-[var(--color-panel)] border-[var(--color-border)] hover:border-[var(--color-accent)]/60"
+                    } disabled:opacity-50`}
+                  >
+                    {workerBusy ? "…" : synapse.workerEnabled ? "Stop worker" : "Start worker"}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+                <span>Listen port:</span>
+                <input
+                  type="number"
+                  value={synapse.workerPort}
+                  disabled={synapse.workerEnabled}
+                  onChange={(e) =>
+                    setSynapseWorkerPort(parseInt(e.target.value, 10) || 50052)
+                  }
+                  className="w-20 bg-[var(--color-panel)] border border-[var(--color-border)] rounded px-2 py-0.5 text-[var(--color-text)] disabled:opacity-50"
+                />
+                <span className="text-[var(--color-text-subtle)]">(default 50052)</span>
+              </div>
+              {workerError && (
+                <div className="mt-2 text-xs text-[var(--color-danger)]">{workerError}</div>
+              )}
+            </div>
+          </div>
+        </Section>
+
+        {/* Discovered peers */}
+        <Section
+          title={`Discovered on LAN (${peerList.length})`}
+          icon={<Radio size={15} />}
+        >
+          <p className="text-xs text-[var(--color-text-muted)] mb-3">
+            LocalMind workers advertise themselves via mDNS (<code>_localmind-synapse._tcp</code>).
+            Click <Plus size={11} className="inline -mt-0.5" /> to add one to your worker list.
+          </p>
+          {peerList.length === 0 ? (
+            <div className="flex items-center gap-2 text-sm text-[var(--color-text-subtle)] py-3">
+              <Search size={14} className="animate-pulse" />
+              No peers yet — start worker mode on another machine on this network.
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-1.5">
+              {peerList.map((p) => {
+                const added = synapse.workers.includes(p.endpoint);
+                return (
+                  <li
+                    key={p.id}
+                    className="flex items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-panel-2)] px-3 py-2"
+                  >
+                    <div className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)]" />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">{p.hostname}</div>
+                      <div className="text-xs text-[var(--color-text-muted)] font-mono truncate">
+                        {p.endpoint}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => addPeer(p)}
+                      disabled={added}
+                      className={`text-xs px-2.5 py-1 rounded-md border flex items-center gap-1 ${
+                        added
+                          ? "bg-[var(--color-panel)] border-[var(--color-border)] text-[var(--color-text-subtle)] cursor-default"
+                          : "bg-[var(--color-panel)] border-[var(--color-border)] hover:border-[var(--color-accent)]/60"
+                      }`}
+                    >
+                      {added ? "Added" : (<><Plus size={11} /> Use</>)}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </Section>
+
+        {/* Workers list (host side) */}
+        <Section title="Workers (this machine is the host)" icon={<Network size={15} />}>
+          <div className="text-xs text-[var(--color-text-muted)] mb-2">
+            Comma- or newline-separated <code>host:port</code>. Applied on the next model
+            load. Leave empty to run only on this machine.
+          </div>
+          <textarea
+            value={workersText}
+            onChange={(e) => commitWorkersText(e.target.value)}
+            placeholder="192.168.1.50:50052, mac-mini.local:50052"
+            rows={3}
+            className="w-full text-sm font-mono bg-[var(--color-panel-2)] border border-[var(--color-border)] rounded-md px-3 py-2 placeholder:text-[var(--color-text-subtle)]"
+          />
+          {synapse.workers.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {synapse.workers.map((w) => (
+                <span
+                  key={w}
+                  className="text-xs font-mono bg-[var(--color-panel-2)] border border-[var(--color-border)] rounded-full pl-2.5 pr-1 py-0.5 flex items-center gap-1"
+                >
+                  {w}
+                  <button
+                    onClick={() => removeWorker(w)}
+                    className="text-[var(--color-text-subtle)] hover:text-[var(--color-danger)] rounded-full w-4 h-4 grid place-items-center"
+                    title="Remove worker"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </Section>
+
+        {/* Live logs */}
+        <Section title="Live logs" icon={<Terminal size={15} />}>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs text-[var(--color-text-subtle)]">
+              {logs.length}/{MAX_LOG_LINES} lines · llama-server (host) + rpc-server (worker)
+            </span>
+            <div className="flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={highlightsOnly}
+                  onChange={(e) => setHighlightsOnly(e.target.checked)}
+                  className="accent-[var(--color-accent)]"
+                />
+                Highlights
+              </label>
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={autoScroll}
+                  onChange={(e) => setAutoScroll(e.target.checked)}
+                  className="accent-[var(--color-accent)]"
+                />
+                Auto-scroll
+              </label>
+              <button
+                onClick={() => setLogs([])}
+                className="flex items-center gap-1 hover:text-[var(--color-text)]"
+                title="Clear logs"
+              >
+                <Trash2 size={12} /> Clear
+              </button>
+            </div>
+          </div>
+          <div
+            ref={logBoxRef}
+            className="font-mono text-[11px] leading-[1.45] bg-black/60 border border-[var(--color-border)] rounded-md p-2.5 h-[260px] overflow-y-auto"
+          >
+            {filteredLogs.length === 0 ? (
+              <div className="text-[var(--color-text-subtle)] italic">
+                Waiting for output… Load a model to see llama-server initialize, or
+                start worker mode to see rpc-server output.
+              </div>
+            ) : (
+              filteredLogs.map((l, i) => (
+                <div
+                  key={i}
+                  className={
+                    l.stream === "stderr"
+                      ? "text-[var(--color-text-muted)]"
+                      : "text-[var(--color-text)]"
+                  }
+                >
+                  <span
+                    className={
+                      l.source === "synapse"
+                        ? "text-[var(--color-accent)]"
+                        : "text-[var(--color-success)]"
+                    }
+                  >
+                    [{l.source === "synapse" ? "rpc-server" : `llama-${l.tag ?? "server"}`}]
+                  </span>{" "}
+                  {l.line}
+                </div>
+              ))
+            )}
+          </div>
+          <div className="mt-1.5 text-[11px] text-[var(--color-text-subtle)]">
+            Highlights: lines mentioning <code>RPC</code>, <code>offload</code>,
+            <code> buffer size</code>, or errors — the signals that confirm a layer
+            split actually happened.
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-6 rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-[var(--color-text-muted)]">{icon}</span>
+        <h2 className="font-semibold text-sm">{title}</h2>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/pages/Synapse.tsx
+++ b/src/pages/Synapse.tsx
@@ -30,8 +30,13 @@ type LogEntry = {
 // inference is actually engaged. Mentioned RPC backends, buffer tables, layer
 // offloads, and any errors qualify — those are the lines that prove a layer
 // split actually happened.
+// Lines we want to surface in the highlights view: anything that proves a
+// distributed inference path is engaged (RPC, offload, layer split), anything
+// about discovery (mDNS, advertise, peer), and any errors. The default-on
+// "Highlights" toggle is meant to skip llama.cpp's chatty progress lines, not
+// hide our own diagnostics — so this list has to cover both.
 const HIGHLIGHT_RE =
-  /\b(rpc|offload|buffer size|backend|n_layer|tensor split|error|failed|timeout)\b/i;
+  /\b(rpc|offload|buffer size|backend|n_layer|tensor split|mdns|advertise|peer|synapse|error|failed|timeout)\b/i;
 
 export function Synapse() {
   const remote = !isTauri();


### PR DESCRIPTION
## feat: Synapse Phase 2 — auto-discovery + GPU runtime fixes

Closes #7 
Builds on Phase 1's manual RPC pipeline-shard with the missing pieces that
made it actually usable: workers find each other automatically, Windows
NVIDIA boxes use their GPU instead of falling back to CPU, and Synapse gets
its own first-class UI surface. 

### What's new

**Auto-discovery (mDNS + UDP beacon)**
- Workers advertise themselves over mDNS as `_localmind-synapse._tcp` with
  sanitized hostname + version TXT records. Hostname is RFC 1123-coerced so
  Windows machines with underscores/spaces register cleanly.
- UDP broadcast beacon (255.255.255.255:50053) runs alongside mDNS as a
  fallback. Many Wi-Fi setups silently drop multicast even when client-to-
  client traffic is allowed (AP isolation, IGMP snooping disabled, Public
  network profile on Windows). Beacon TTL-ages out stale workers after 15s.
- Host merges both sources, deduped by endpoint.

**Dedicated Synapse page**
- Moved out of Settings into its own sidebar entry.
- Three sections: this machine (worker toggle + restart), Discovered on LAN
  (one-click "Use" to add a peer), Workers (chip list with × to remove).
- Live logs panel with `llama-server` + `rpc-server` streams interleaved,
  Highlights filter, auto-scroll, clear.

**Restart worker**
- New `restart_synapse_worker` Tauri command — stops the rpc-server child,
  waits, re-spawns. Flushes any VRAM that llama.cpp left allocated when a
  host disconnected mid-inference.

**Windows + NVIDIA: actually use the GPU**
- Auto-fetch llama.cpp's `cudart-*` sibling archive on first install for
  NVIDIA + Windows. Without it, `ggml-cuda.dll` silently fails LoadLibrary
  due to missing `cudart64_*.dll` / `cublas64_*.dll`, and llama.cpp falls
  back to CPU with no warning.
- cudart picker matches the CUDA version of the binary archive
  (e.g. cu13.1 binaries → cu13.1 cudart). Mismatched runtimes surface as
  confusing init failures.
- Existing installs can force a fresh fetch by deleting `bin/`.

### Tested with
- Mac (M1 Pro, host) ↔ Windows (RTX 5070 Ti, Blackwell, worker)
- mDNS path failed on the test Wi-Fi (multicast filtered); UDP beacon
  saved discovery
- After cu13.1 swap on Windows: GPU offload confirmed via nvidia-smi,
  `compute capability 12.0` in rpc-server logs

### Known limitations (deferred to Phase 3)
- No auth on the RPC wire — still LAN-trusted-network only
- No tok/s telemetry per worker
- Smart layer split / explicit tensor-split UI not yet exposed
- "Marketplace size hints" (warn when a model needs Synapse) not yet wired

### Files changed
- `src-tauri/src/synapse.rs` — mDNS advertise/browse, UDP beacon, restart
- `src-tauri/src/binaries.rs` — cudart auto-fetch, version-matching picker
- `src-tauri/src/lib.rs` — new commands, discovery on app boot
- `src-tauri/Cargo.toml` — `mdns-sd`, `hostname` deps
- `src/pages/Synapse.tsx` — new page
- `src/pages/Settings.tsx` — Synapse section removed (lives on its own page)
- `src/components/Sidebar.tsx`, `src/App.tsx` — new nav entry + route
- `src/lib/{api,store,types}.ts` — peer types + new commands

### How to test
1. Pull this branch, install on two LAN machines
2. On worker machine: Synapse → Start worker
3. On host machine: Synapse → "Discovered on LAN" should populate within
   a few seconds. If only the UDP beacon route surfaces (mDNS card stays
   empty), your Wi-Fi is filtering multicast — that's the expected
   fallback path.
4. Click "Use" → load a model → check live logs for `RPC` / `offload`
   lines confirming layer shard onto the worker
5. Windows NVIDIA: confirm GPU usage via `nvidia-smi` during inference