### PR TITLE
feat: ship prebuilt installers via Tauri NSIS bundler + tauri-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,21 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
+  release:
+    types: [created, published]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
-  # ── Frontend ────────────────────────────────────────────────────────────────
   frontend:
     name: Frontend (tsc + build)
     runs-on: ubuntu-latest
@@ -32,10 +38,8 @@ jobs:
       - name: Production build
         run: npm run build
         env:
-          # Tauri injects this; stub it out so the Vite build succeeds in CI.
           TAURI_ENV_PLATFORM: linux
 
-  # ── Backend ─────────────────────────────────────────────────────────────────
   backend:
     name: Backend (fmt + clippy + check)
     runs-on: ubuntu-latest
@@ -71,7 +75,169 @@ jobs:
         working-directory: src-tauri
         run: cargo check --all-targets
 
-  # ── Summary gate (single branch-protection target) ──────────────────────────
+  release-desktop:
+    name: Release Desktop (${{ matrix.platform }})
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
+    needs: [frontend, backend]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux system deps
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Set bundle version from tag
+        shell: bash
+        env:
+          TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          echo "Setting version to $VERSION (from tag $TAG)"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          jq --arg v "$VERSION" '.version = $v' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+          mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+          sed -i.bak "s/^version = \".*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml
+          rm src-tauri/Cargo.toml.bak
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: "${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          releaseName: "LocalMind ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          releaseDraft: ${{ github.event_name != 'release' }}
+          prerelease: false
+          releaseBody: |
+            **Downloads**
+            - Windows: `LocalMind_*_x64-setup.exe`
+            - macOS: `LocalMind_*.dmg`
+            - Linux: `localmind_*_amd64.deb` / `LocalMind_*_amd64.AppImage`
+            - Android: `LocalMind_*_android-debug.apk` (tech preview)
+
+            > **macOS first launch:** the app is unsigned. After moving it to Applications, run `xattr -cr /Applications/LocalMind.app` once in Terminal, then open normally.
+
+  release-android:
+    name: Release Android (APK)
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
+    needs: [frontend, backend]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+        with:
+          packages: 'platform-tools platforms;android-34 build-tools;34.0.0 ndk;26.1.10909125'
+
+      - name: Export NDK_HOME
+        run: |
+          echo "NDK_HOME=$ANDROID_HOME/ndk/26.1.10909125" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_HOME/ndk/26.1.10909125" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: android
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Set bundle version from tag
+        shell: bash
+        env:
+          TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          ANDROID_VERSION=$(echo "$VERSION" | sed -E 's/^0\.0\.0(-.*)?$/0.0.1\1/')
+          if [ "$VERSION" != "$ANDROID_VERSION" ]; then
+            echo "Android rejects 0.0.0; bumping $VERSION -> $ANDROID_VERSION for the APK build"
+          fi
+          jq --arg v "$ANDROID_VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          jq --arg v "$ANDROID_VERSION" '.version = $v' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+          mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+          sed -i.bak "s/^version = \".*\"/version = \"$ANDROID_VERSION\"/" src-tauri/Cargo.toml
+          rm src-tauri/Cargo.toml.bak
+
+      - name: Initialize Tauri Android project
+        run: npm run tauri android init
+
+      - name: Build APK (debug)
+        run: npm run tauri android build -- --apk --debug
+
+      - name: Locate APK
+        id: apk
+        run: |
+          APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' | head -n 1)
+          if [ -z "$APK" ]; then
+            echo "No APK produced" >&2
+            exit 1
+          fi
+          echo "path=$APK" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: localmind-android-debug
+          path: ${{ steps.apk.outputs.path }}
+
+      - name: Attach APK to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          DEST="LocalMind_${VERSION}_android-debug.apk"
+          cp "${{ steps.apk.outputs.path }}" "$DEST"
+          for i in 1 2 3 4 5; do
+            if gh release upload "$TAG" "$DEST" --clobber; then
+              exit 0
+            fi
+            echo "Release not ready yet, retrying in 10s ($i/5)..."
+            sleep 10
+          done
+          echo "Failed to upload APK to release $TAG" >&2
+          exit 1
+
   ci:
     name: CI
     needs: [frontend, backend]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ LocalMind is a desktop app that runs open-source language models locally and exp
 |------|-------------|
 | ![LocalMind chat view](assets/screenshots/home_page.png) | ![LocalMind marketplace](assets/screenshots/marketplace.png) |
 
+## Install
+
+Grab a prebuilt installer from the [Releases page](https://github.com/s-suryakiran/LocalMind/releases) — no toolchain required:
+
+| Platform | File |
+|---|---|
+| Windows | `LocalMind_<version>_x64-setup.exe` (NSIS installer) |
+| macOS (Apple Silicon) | `LocalMind_<version>_aarch64.dmg` |
+| Linux | `localmind_<version>_amd64.deb` / `LocalMind_<version>_amd64.AppImage` |
+| Android (preview) | `LocalMind_<version>_android-debug.apk` |
+
+> **macOS:** these builds are not yet code-signed. After dragging `LocalMind.app` to Applications you may see *"LocalMind is damaged and can't be opened"* — that's macOS Gatekeeper quarantining unsigned downloads, **not** actual corruption. Strip the quarantine attribute once and it will open normally:
+>
+> ```bash
+> xattr -cr /Applications/LocalMind.app
+> ```
+>
+> **Windows:** SmartScreen may show *"Windows protected your PC"* on first launch — click **More info** → **Run anyway**. Both warnings will go away once we add code-signing.
+
+Or [build from source](#quickstart) if you'd rather hack on it.
+
 ## Quickstart
 
 ### Prerequisites

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["nsis", "app", "dmg", "deb", "appimage"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## What changed and why

Closes #12. End users currently have to clone the repo and set up a full dev toolchain (Rust + Node + VS Build Tools) just to install LocalMind. This extends the existing CI workflow with release jobs that build platform-native installers (`.exe`, `.dmg`, `.deb`, `.AppImage`, `.apk`) and attach them to GitHub Releases when a `v*` tag is pushed — no toolchain required for end users.

## How to test

1. Push a test tag: `git tag v0.0.1-test.1 && git push origin v0.0.1-test.1`
2. Watch **Actions** — `frontend` + `backend` run first, then 4 release jobs start in parallel. Total ~12 min.
3. A draft release appears at https://github.com/s-suryakiran/LocalMind/releases with 5 installers. Verify filenames match the tag (e.g. `LocalMind_0.0.1-test.1_x64-setup.exe`).
4. Clean up: delete the draft release in the UI + `git push origin --delete v0.0.1-test.1`.

Verified on my fork across 4 test runs — all 5 installers built successfully in 12m15s: https://github.com/kavya-sureshkumar/LocalMind/actions/runs/25191526135

## Checklist

- [x] `npx tsc --noEmit` passes (no TS code touched; CI confirmed green)
- [x] `npm run build` succeeds (verified locally — produced 9.3 MB `.app` + 5.4 MB `.dmg`)
- [x] `cargo fmt --all -- --check` passes (no Rust code touched)
- [x] `cargo clippy --all-targets -- -D warnings` passes (no Rust code touched)
- [x] Manually tested on macOS — local `npm run tauri build` produces `.dmg` + `.app`. Full Win/Mac/Linux/Android matrix verified by pushing test tags through the new workflow on my fork.
- [x] Docs / README updated — added `## Install` section with download table and macOS Gatekeeper / Windows SmartScreen callout
- [x] No new dependencies added

## Related issues

Closes #12
