### PR TITLE
Feature/synapse workers phase4

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -234,6 +234,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +593,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1313,6 +1344,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -2403,7 +2440,10 @@ dependencies = [
  "local-ip-address",
  "mdns-sd",
  "rand 0.8.6",
+ "rcgen",
  "reqwest 0.12.28",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
@@ -2418,6 +2458,7 @@ dependencies = [
  "tauri-plugin-store",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http 0.5.2",
@@ -2960,6 +3001,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -3586,6 +3637,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,12 +3876,23 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3836,6 +3911,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6503,6 +6579,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,13 @@ hmac = "0.12"
 sha2 = "0.10"
 rand = { version = "0.8", features = ["std_rng"] }
 subtle = "2"
+# Phase 4 chunk N: TLS on the Synapse proxy. rcgen generates the self-
+# signed cert; tokio-rustls wraps the TCP streams. We pin the rustls
+# version explicitly because rcgen tracks it.
+rcgen = "0.13"
+tokio-rustls = "0.26"
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
+rustls-pemfile = "2"
 
 [profile.release]
 lto = true

--- a/src-tauri/src/auth_proxy.rs
+++ b/src-tauri/src/auth_proxy.rs
@@ -23,12 +23,22 @@
 // upstream protocol.
 
 use crate::synapse_proto::{self, HandshakeResponse, PROTOCOL_VERSION};
+use crate::synapse_tls;
 use anyhow::{anyhow, Result};
 use serde::Serialize;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
+use tokio_rustls::TlsAcceptor;
+
+/// Phase 4 chunk O: live count of authenticated client connections.
+/// Process-global because there's only ever one auth proxy running per
+/// app, and exposing it as a simple atomic avoids threading a
+/// `SynapseState` reference into every per-connection task.
+pub static ACTIVE_SESSIONS: AtomicU32 = AtomicU32::new(0);
 
 /// What we tell the UI when a client tries to connect. Front-end mirrors
 /// these into the live-logs panel and a future "active connections" badge.
@@ -63,9 +73,20 @@ pub async fn spawn_auth_proxy(
     let listener = TcpListener::bind(("0.0.0.0", public_port))
         .await
         .map_err(|e| anyhow!("auth proxy bind 0.0.0.0:{public_port}: {e}"))?;
+
+    // Phase 4 chunk N: every accepted connection gets wrapped in TLS before
+    // we read a single application byte. The handshake JSON, token, and
+    // raw rpc traffic all flow inside the TLS tunnel. Build the acceptor
+    // once and clone the Arc per-connection.
+    let (certs, key, fingerprint) = synapse_tls::load_or_create_cert()?;
+    let tls_config = synapse_tls::server_config(certs, key)?;
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
     log_info(
         &app,
-        &format!("auth proxy listening on 0.0.0.0:{public_port} → 127.0.0.1:{internal_port}"),
+        &format!(
+            "auth proxy listening on 0.0.0.0:{public_port} → 127.0.0.1:{internal_port} (TLS, fp={})",
+            &fingerprint[..16]
+        ),
     );
 
     let handle = tokio::spawn(async move {
@@ -74,10 +95,27 @@ pub async fn spawn_auth_proxy(
                 Ok((client, peer)) => {
                     let app = app.clone();
                     let token = token.clone();
+                    let acceptor = acceptor.clone();
                     tokio::spawn(async move {
                         let peer_str = peer.to_string();
+                        // Wrap in TLS first. A peer that doesn't speak TLS
+                        // (e.g. a port scanner sending raw HTTP) gets a
+                        // clean drop here without ever reaching the
+                        // application layer.
+                        let tls_stream = match acceptor.accept(client).await {
+                            Ok(s) => s,
+                            Err(e) => {
+                                emit_auth(
+                                    &app,
+                                    AuthEventKind::Rejected,
+                                    &peer_str,
+                                    Some(format!("tls handshake: {e}")),
+                                );
+                                return;
+                            }
+                        };
                         if let Err(e) =
-                            handle_client(client, &token, internal_port, &app, &peer_str).await
+                            handle_client(tls_stream, &token, internal_port, &app, &peer_str).await
                         {
                             // Swallow the error here so a single misbehaving
                             // peer doesn't take down the whole proxy. Most
@@ -99,7 +137,7 @@ pub async fn spawn_auth_proxy(
 }
 
 async fn handle_client(
-    mut client: TcpStream,
+    mut client: tokio_rustls::server::TlsStream<TcpStream>,
     expected_token: &str,
     internal_port: u16,
     app: &AppHandle,
@@ -185,6 +223,13 @@ async fn handle_client(
         }
     };
 
+    // Phase 4 chunk O: bump the session counter at accept, decrement at
+    // disconnect. We do this *after* the upstream dial succeeds so half-
+    // open dial failures don't show up as ghost sessions. The
+    // increment/decrement is wrapped to make the dec happen even on panic
+    // via a guard struct.
+    let _guard = SessionGuard::enter(app);
+
     emit_auth(app, AuthEventKind::Accepted, peer, None);
 
     // Phase 3: bidirectional byte copy. tokio's helper is the right tool —
@@ -197,6 +242,35 @@ async fn handle_client(
 
     emit_auth(app, AuthEventKind::Disconnected, peer, None);
     Ok(())
+}
+
+/// RAII session counter. Increments on construction, decrements + emits a
+/// fresh count on drop — including on panic, so a misbehaving rpc-server
+/// can't strand the counter at a wrong value.
+struct SessionGuard {
+    app: AppHandle,
+}
+
+impl SessionGuard {
+    fn enter(app: &AppHandle) -> Self {
+        let count = ACTIVE_SESSIONS.fetch_add(1, Ordering::Relaxed) + 1;
+        let _ = app.emit("synapse:sessions", serde_json::json!({ "count": count }));
+        Self { app: app.clone() }
+    }
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        // saturating_sub-ish: subtract 1 but never wrap. If something else
+        // miscounted (impossible today, but cheap insurance), clamp to 0.
+        let prev = ACTIVE_SESSIONS.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+            Some(c.saturating_sub(1))
+        });
+        let count = prev.map(|p| p.saturating_sub(1)).unwrap_or(0);
+        let _ = self
+            .app
+            .emit("synapse:sessions", serde_json::json!({ "count": count }));
+    }
 }
 
 fn emit_auth(app: &AppHandle, kind: AuthEventKind, peer: &str, reason: Option<String>) {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -60,3 +60,14 @@ pub fn sd_output_dir() -> PathBuf {
 pub fn synapse_token_path() -> PathBuf {
     data_dir().join("synapse-token.txt")
 }
+
+/// Phase 4 chunk N: paths to the worker's persisted self-signed TLS cert
+/// (PEM) and matching private key. Generated alongside the token on first
+/// worker start. Together with the token they form the worker's identity.
+pub fn synapse_cert_path() -> PathBuf {
+    data_dir().join("synapse-cert.pem")
+}
+
+pub fn synapse_key_path() -> PathBuf {
+    data_dir().join("synapse-key.pem")
+}

--- a/src-tauri/src/host_proxy.rs
+++ b/src-tauri/src/host_proxy.rs
@@ -27,12 +27,17 @@
 // without a port allocator.
 
 use crate::synapse_proto::{self, HandshakeRequest, PROTOCOL_VERSION};
+use crate::synapse_tls;
 use anyhow::{anyhow, bail, Result};
+use rustls::pki_types::ServerName;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::TlsConnector;
 
 pub struct HostProxy {
     /// Active local listeners, one per worker. We just need to abort them on
@@ -58,17 +63,30 @@ impl HostProxy {
     /// abort the whole start_llama call so the user sees the failure
     /// directly rather than ending up with a half-loaded model that can't
     /// actually serve.
-    pub async fn start(&self, app: &AppHandle, remote: &str, token: &str) -> Result<String> {
+    pub async fn start(
+        &self,
+        app: &AppHandle,
+        remote: &str,
+        token: &str,
+        fingerprint: Option<&str>,
+    ) -> Result<String> {
         if token.trim().is_empty() {
             bail!(
                 "no token configured for worker {remote} — paste the worker's token in the Synapse tab"
             );
         }
 
+        // Phase 4 chunk N: a missing fingerprint isn't fatal — older workers
+        // (Phase 3) didn't advertise one, and the user might not have
+        // re-paired since updating. Without the pin, we still negotiate
+        // TLS but accept any cert (TOFU). The token still gates access
+        // application-side, so this isn't a regression vs Phase 3.
+        let fingerprint_owned = fingerprint.map(|s| s.to_ascii_lowercase());
+
         // Probe handshake: dial, handshake, hang up. Cheap (~1 RTT) and gives
         // immediate, correct error messages for the three failure modes a
         // user actually hits: wrong token, unreachable worker, version mismatch.
-        probe_handshake(remote, token)
+        probe_handshake(remote, token, fingerprint_owned.as_deref())
             .await
             .map_err(|e| anyhow!("auth probe to {remote}: {e}"))?;
 
@@ -86,18 +104,46 @@ impl HostProxy {
             &format!("local proxy {local} → {remote} (auth OK, probe verified)"),
         );
 
+        // Phase 4 chunk K: shared health flag flipped by the pinger and
+        // read by the listener. When the worker is evicted (heartbeat
+        // failed for 30s+), accepting a connection and trying to forward
+        // would hang llama-server's dial — better to reject fast with a
+        // clean TCP RST so the user gets an immediate "connection refused"
+        // and can debug. Recovery flips it back automatically.
+        let healthy = Arc::new(AtomicBool::new(true));
+        let healthy_listener = healthy.clone();
+        let healthy_pinger = healthy.clone();
+
         let remote_owned = remote.to_string();
         let token_owned = token.to_string();
+        let fingerprint_listener = fingerprint_owned.clone();
         let app_outer = app.clone();
         let task = tokio::spawn(async move {
             loop {
                 match listener.accept().await {
                     Ok((client, _peer)) => {
+                        if !healthy_listener.load(Ordering::Relaxed) {
+                            // Drop immediately. We don't even handshake —
+                            // this saves llama-server from waiting on a
+                            // probe to a dead worker. Closing the socket
+                            // gives it a clean RST inside ~1 ms.
+                            drop(client);
+                            log_warn(
+                                &app_outer,
+                                &format!(
+                                    "local proxy → {remote_owned}: refusing client (worker offline)"
+                                ),
+                            );
+                            continue;
+                        }
                         let remote = remote_owned.clone();
                         let token = token_owned.clone();
+                        let fingerprint = fingerprint_listener.clone();
                         let app = app_outer.clone();
                         tokio::spawn(async move {
-                            if let Err(e) = forward(client, &remote, &token).await {
+                            if let Err(e) =
+                                forward(client, &remote, &token, fingerprint.as_deref()).await
+                            {
                                 // One bad connection shouldn't tear the proxy
                                 // down. Surface the error via the live-logs
                                 // stream so users can see if e.g. their worker
@@ -123,28 +169,79 @@ impl HostProxy {
         // gives the UI a live signal of network health independent of
         // whether inference is running. Bundled into the same JoinHandle
         // pool so stop_all() takes both down together.
+        //
+        // Phase 4 chunk I: count consecutive failures. After EVICT_AFTER
+        // misses (~30s of silence) we emit `synapse:proxy-evicted` and stop
+        // pinging. The proxy listener stays up so a future model load still
+        // surfaces a clear "auth probe to X" error rather than silently
+        // missing a worker. Chunk K (reconnect) will re-arm the pinger when
+        // the worker comes back.
         let remote_ping = remote.to_string();
         let token_ping = token.to_string();
+        let fingerprint_ping = fingerprint_owned.clone();
         let app_ping = app.clone();
         let pinger = tokio::spawn(async move {
+            const EVICT_AFTER: u32 = 6;
             let mut ticker = tokio::time::interval(std::time::Duration::from_secs(5));
             // First tick fires immediately; skip it so we don't pile a probe
             // on top of the start-of-load handshake the caller already did.
             ticker.tick().await;
+            let mut consecutive_fails: u32 = 0;
+            let mut evicted = false;
             loop {
                 ticker.tick().await;
                 let started = std::time::Instant::now();
-                let result = probe_handshake(&remote_ping, &token_ping).await;
+                let result =
+                    probe_handshake(&remote_ping, &token_ping, fingerprint_ping.as_deref()).await;
                 let elapsed_ms = started.elapsed().as_millis() as u64;
+                let ok = result.is_ok();
                 let _ = app_ping.emit(
                     "synapse:rtt",
                     serde_json::json!({
                         "endpoint": &remote_ping,
                         "rttMs": elapsed_ms,
-                        "ok": result.is_ok(),
+                        "ok": ok,
                         "ts": now_ms(),
                     }),
                 );
+                if ok {
+                    if evicted {
+                        // Worker came back — flip the listener back to
+                        // accepting connections, emit recovery so UI
+                        // restores its place in the active list, and reset
+                        // the ticker to its normal cadence.
+                        healthy_pinger.store(true, Ordering::Relaxed);
+                        let _ = app_ping.emit(
+                            "synapse:proxy-recovered",
+                            serde_json::json!({ "endpoint": &remote_ping, "ts": now_ms() }),
+                        );
+                        evicted = false;
+                        ticker = tokio::time::interval(std::time::Duration::from_secs(5));
+                        ticker.tick().await; // burn immediate tick
+                    }
+                    consecutive_fails = 0;
+                } else {
+                    consecutive_fails = consecutive_fails.saturating_add(1);
+                    if consecutive_fails == EVICT_AFTER && !evicted {
+                        evicted = true;
+                        // Flip listener BEFORE emitting so a racing client
+                        // connection sees the unhealthy state.
+                        healthy_pinger.store(false, Ordering::Relaxed);
+                        let _ = app_ping.emit(
+                            "synapse:proxy-evicted",
+                            serde_json::json!({
+                                "endpoint": &remote_ping,
+                                "afterMs": (EVICT_AFTER as u64) * 5_000,
+                                "ts": now_ms(),
+                            }),
+                        );
+                        // Slow the ticker after eviction so we don't hammer
+                        // a sleeping worker — once a minute is plenty for
+                        // detecting "it's back."
+                        ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+                        ticker.tick().await; // burn the immediate tick
+                    }
+                }
             }
         });
         self.proxies.lock().await.push(pinger);
@@ -162,11 +259,22 @@ impl HostProxy {
     }
 }
 
-async fn probe_handshake(remote: &str, token: &str) -> Result<()> {
-    // Connect timeout matters here — if the worker's at a stale IP we don't
-    // want to make the user wait for the OS's default 75s. 5s is plenty for
-    // a healthy LAN.
-    let mut sock = tokio::time::timeout(
+/// Open a TLS-wrapped TCP connection to the remote auth proxy. The TLS
+/// verifier pins the cert fingerprint when one is supplied; without one
+/// we accept any cert (TOFU) and rely on the application-layer token to
+/// gate access. Both probe and forward go through here for consistency.
+async fn open_tls(remote: &str, fingerprint: Option<&str>) -> Result<TlsStream<TcpStream>> {
+    let (host_str, _port_str) = remote
+        .rsplit_once(':')
+        .ok_or_else(|| anyhow!("malformed endpoint {remote} (need host:port)"))?;
+    // rustls needs a SNI name even though our pinned verifier ignores
+    // the chain. Pass the literal hostname/IP the user typed.
+    let server_name = ServerName::try_from(host_str.to_string())
+        .map_err(|e| anyhow!("invalid TLS server name {host_str}: {e}"))?;
+
+    // Connect timeout matters — a stale IP shouldn't make the user wait
+    // for the OS default (~75s). 5s is plenty for a healthy LAN.
+    let tcp = tokio::time::timeout(
         std::time::Duration::from_secs(5),
         TcpStream::connect(remote),
     )
@@ -174,6 +282,23 @@ async fn probe_handshake(remote: &str, token: &str) -> Result<()> {
     .map_err(|_| anyhow!("connect timeout (5s) — is the worker reachable?"))?
     .map_err(|e| anyhow!("connect: {e}"))?;
 
+    let cfg = match fingerprint {
+        Some(fp) => synapse_tls::client_config_pinning(fp.to_string())?,
+        // Empty pin = TOFU. The verifier rejects every non-empty cert
+        // against an empty fingerprint, so we'd never connect; instead
+        // pass a sentinel that matches anything by short-circuiting.
+        None => synapse_tls::client_config_pinning(String::new())?,
+    };
+    let connector = TlsConnector::from(Arc::new(cfg));
+    let tls = connector
+        .connect(server_name, tcp)
+        .await
+        .map_err(|e| anyhow!("tls handshake: {e}"))?;
+    Ok(tls)
+}
+
+async fn probe_handshake(remote: &str, token: &str, fingerprint: Option<&str>) -> Result<()> {
+    let mut sock = open_tls(remote, fingerprint).await?;
     let req = HandshakeRequest {
         v: PROTOCOL_VERSION,
         token: token.to_string(),
@@ -189,10 +314,13 @@ async fn probe_handshake(remote: &str, token: &str) -> Result<()> {
     Ok(())
 }
 
-async fn forward(client: TcpStream, remote: &str, token: &str) -> Result<()> {
-    let mut upstream = TcpStream::connect(remote)
-        .await
-        .map_err(|e| anyhow!("connect upstream {remote}: {e}"))?;
+async fn forward(
+    client: TcpStream,
+    remote: &str,
+    token: &str,
+    fingerprint: Option<&str>,
+) -> Result<()> {
+    let mut upstream = open_tls(remote, fingerprint).await?;
     let req = HandshakeRequest {
         v: PROTOCOL_VERSION,
         token: token.to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -316,6 +316,12 @@ fn generate_pin() -> String {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // rustls 0.23 sees both `ring` and `aws-lc-rs` providers via transitive
+    // deps (reqwest's rustls-tls pulls hyper-rustls which enables aws-lc-rs).
+    // With both features on, rustls refuses to auto-pick one and panics on
+    // first TLS use. Pin ring explicitly. Err on re-entry is harmless.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let llama = LlamaState::new();
     let rag = RagState::new();
     let sd = SdState::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod sd;
 mod server;
 mod synapse;
 mod synapse_proto;
+mod synapse_tls;
 mod synapse_token;
 
 use llama::{LlamaSettings, LlamaState, LlamaStatus};
@@ -300,6 +301,14 @@ async fn set_known_synapse_tokens(
     Ok(())
 }
 
+#[tauri::command]
+fn synapse_active_sessions() -> u32 {
+    // Phase 4 chunk O: read the global counter for the worker UI's
+    // "X hosts connected" badge. The Rust process is single-tenant so
+    // a global atomic is the right shape here.
+    auth_proxy::ACTIVE_SESSIONS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 fn generate_pin() -> String {
     let raw = uuid::Uuid::new_v4().as_u128();
     format!("{:06}", (raw % 1_000_000) as u32)
@@ -336,12 +345,25 @@ pub fn run() {
             let llama2 = llama.clone();
             let pin2 = pin.clone();
             let tokens2 = tokens.clone();
+            // Phase 4 chunk P: clone the SynapseState so the LAN server
+            // can serve read-only views to the phone PWA. The discovery
+            // task below reuses the same Arc.
+            let synapse_for_server = synapse.clone();
             let synapse2 = synapse.clone();
             let handle_for_discovery = handle.clone();
             tauri::async_runtime::spawn(async move {
                 let resource_dir = handle.path().resource_dir().ok();
                 let static_dir = resource_dir.map(|d| d.join("dist")).filter(|p| p.exists());
-                match server::start_lan_server(llama2, static_dir, 3939, pin2, tokens2).await {
+                match server::start_lan_server(
+                    llama2,
+                    static_dir,
+                    3939,
+                    pin2,
+                    tokens2,
+                    synapse_for_server,
+                )
+                .await
+                {
                     Ok(url) => {
                         holder2.lan_url.set(url.clone());
                         let _ = handle.emit("lan:ready", url);
@@ -390,6 +412,7 @@ pub fn run() {
             get_synapse_token,
             rotate_synapse_token,
             set_known_synapse_tokens,
+            synapse_active_sessions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -235,9 +235,14 @@ impl LlamaState {
                     || active_workers.iter().any(|w| w.weight.is_some());
                 if any_explicit {
                     let mut weights: Vec<f32> = Vec::with_capacity(active_workers.len() + 1);
-                    weights.push(settings.host_weight.unwrap_or(1.0).max(0.0));
+                    // Default 0.5 matches the UI slider's visual resting
+                    // position. `unwrap_or(1.0)` made an untouched worker
+                    // silently outweigh a host the user had dialed back to
+                    // a low value, which inverted the layer split versus
+                    // what the sliders showed.
+                    weights.push(settings.host_weight.unwrap_or(0.5).max(0.0));
                     for w in &active_workers {
-                        weights.push(w.weight.unwrap_or(1.0).max(0.0));
+                        weights.push(w.weight.unwrap_or(0.5).max(0.0));
                     }
                     // Normalize so the user can think in percentages without
                     // worrying about the sum. llama.cpp accepts comma-

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -25,6 +25,13 @@ pub struct SynapseWorker {
     /// `None` (or 0.0) means "use llama.cpp's default" — even split.
     #[serde(default)]
     pub weight: Option<f32>,
+    /// Phase 4 chunk N: pinned cert fingerprint. The host's TLS verifier
+    /// rejects any cert that doesn't match this hash, so a peer at the
+    /// same IP can't impersonate the worker even if it learns the token.
+    /// Captured by the host on first pairing from the (HMAC-verified)
+    /// beacon. `None` means "fall back to first-seen TOFU on connect."
+    #[serde(default)]
+    pub cert_fingerprint: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -196,7 +203,11 @@ impl LlamaState {
                 if endpoint.is_empty() {
                     continue;
                 }
-                match self.host_proxy.start(app, endpoint, &w.token).await {
+                match self
+                    .host_proxy
+                    .start(app, endpoint, &w.token, w.cert_fingerprint.as_deref())
+                    .await
+                {
                     Ok(local) => {
                         local_addrs.push(local);
                         active_workers.push(w);
@@ -341,6 +352,11 @@ fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {
         let tag = tag.to_string();
         tokio::spawn(async move {
             let mut lines = BufReader::new(stderr).lines();
+            // Phase 4 chunk Q: cluster-viz layout state. Collect device-
+            // buffer lines as they stream and flush a single layout event
+            // when llama-server signals load completion. One render
+            // instead of N flickering ones.
+            let mut device_buffers: Vec<(String, u64)> = Vec::new();
             while let Ok(Some(line)) = lines.next_line().await {
                 // Phase 3 chunk F1: tok/s parser. llama.cpp's per-request
                 // timing block looks like:
@@ -362,6 +378,30 @@ fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {
                             }),
                         );
                     }
+                    if let Some((device, mb)) = parse_buffer_line(&line) {
+                        device_buffers.push((device, mb));
+                    }
+                    // Heralds load-complete: emit one layout event with
+                    // every device-buffer we collected, then clear so a
+                    // model reload starts fresh.
+                    if !device_buffers.is_empty()
+                        && (line.contains("model loaded")
+                            || line.contains("loaded successfully")
+                            || line.contains("HTTP server listening")
+                            || line.contains("starting the main loop"))
+                    {
+                        let _ = app.emit(
+                            "synapse:cluster-layout",
+                            serde_json::json!({
+                                "devices": device_buffers
+                                    .iter()
+                                    .map(|(d, mb)| serde_json::json!({ "device": d, "mb": mb }))
+                                    .collect::<Vec<_>>(),
+                                "ts": now_ms(),
+                            }),
+                        );
+                        device_buffers.clear();
+                    }
                 }
                 let _ = app.emit(
                     "llama:log",
@@ -370,6 +410,35 @@ fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {
             }
         });
     }
+}
+
+/// Phase 4 chunk Q: extract a (device, MiB) pair from llama.cpp's tensor-
+/// loading log. Real lines look like:
+///
+///     load_tensors: CUDA0 model buffer size = 12345.67 MiB
+///     load_tensors: CPU model buffer size  =   234.56 MiB
+///     load_tensors: RPC[127.0.0.1:54712] model buffer size = 9876.54 MiB
+///
+/// Returns None for unrelated lines. We deliberately key off "model buffer
+/// size" rather than just "buffer size" because llama.cpp also prints
+/// transient KV-cache sizes that aren't part of the layout snapshot.
+fn parse_buffer_line(line: &str) -> Option<(String, u64)> {
+    if !line.contains("model buffer size") {
+        return None;
+    }
+    let after_prefix = line.split_once("load_tensors:").map(|(_, r)| r)?;
+    let (device_part, size_part) = after_prefix.split_once("model buffer size")?;
+    let device = device_part.trim().to_string();
+    if device.is_empty() {
+        return None;
+    }
+    let num: String = size_part
+        .chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    let mb: f64 = num.parse().ok()?;
+    Some((device, mb as u64))
 }
 
 /// Extract `tokens per second` from an llama.cpp eval-time log line, e.g.
@@ -473,7 +542,32 @@ async fn wait_ready(port: u16) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_eval_tok_per_sec;
+    use super::{parse_buffer_line, parse_eval_tok_per_sec};
+
+    #[test]
+    fn parses_buffer_lines_real_format() {
+        let cuda = "load_tensors: CUDA0 model buffer size = 12345.67 MiB";
+        assert_eq!(parse_buffer_line(cuda), Some(("CUDA0".to_string(), 12345)));
+
+        let cpu = "load_tensors: CPU model buffer size  =   234.56 MiB";
+        assert_eq!(parse_buffer_line(cpu), Some(("CPU".to_string(), 234)));
+
+        let rpc = "load_tensors: RPC[127.0.0.1:54712] model buffer size = 9876.54 MiB";
+        assert_eq!(
+            parse_buffer_line(rpc),
+            Some(("RPC[127.0.0.1:54712]".to_string(), 9876))
+        );
+    }
+
+    #[test]
+    fn rejects_kv_cache_and_unrelated_lines() {
+        assert_eq!(
+            parse_buffer_line("llama_kv_cache: CUDA0 KV buffer size = 256 MiB"),
+            None
+        );
+        assert_eq!(parse_buffer_line("loading model"), None);
+        assert_eq!(parse_buffer_line(""), None);
+    }
 
     #[test]
     fn parses_eval_tok_per_sec_real_format() {

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1,4 +1,5 @@
 use crate::llama::LlamaState;
+use crate::synapse::SynapseState;
 use anyhow::Result;
 use axum::{
     body::Body,
@@ -22,6 +23,9 @@ pub struct AppState {
     pub http: reqwest::Client,
     pub pin: String,
     pub tokens: Arc<Mutex<HashSet<String>>>,
+    /// Phase 4 chunk P: SynapseState handle so the LAN server can serve a
+    /// read-only view of the worker + discovered peers to paired phones.
+    pub synapse: Arc<SynapseState>,
 }
 
 #[derive(Deserialize)]
@@ -40,18 +44,33 @@ pub async fn start_lan_server(
     port: u16,
     pin: String,
     tokens: Arc<Mutex<HashSet<String>>>,
+    synapse: Arc<SynapseState>,
 ) -> Result<String> {
     let state = AppState {
         llama,
         http: reqwest::Client::new(),
         pin,
         tokens,
+        synapse,
     };
 
     let mut app = Router::new()
         .route("/api/health", get(health))
         .route("/api/pair", post(pair))
         .route("/api/status", get(status))
+        // Phase 4 chunk P: read-only Synapse views for paired phones/iPads.
+        // The phone can't actually drive the worker (start/stop, edit
+        // tokens, change splits) — those stay desktop-only — but it can
+        // observe everything the desktop sees.
+        .route("/api/synapse/status", get(synapse_status))
+        .route("/api/synapse/peers", get(synapse_peers))
+        .route("/api/synapse/sessions", get(synapse_sessions))
+        // Phase 4 chunk R: Prometheus-format metrics. Plain text scrape
+        // target at /metrics, no client lib dep — the format is small
+        // enough to hand-roll. Auth still applies via the same Bearer
+        // gate as the rest of /api, so a paired Prometheus server reaches
+        // it but a drive-by scrape doesn't.
+        .route("/api/metrics", get(prometheus_metrics))
         .route("/v1/*rest", any(proxy_v1))
         .route("/health", get(proxy_health))
         // Vite's HMR client polls this when its WebSocket drops; on a 200 it
@@ -237,4 +256,122 @@ async fn forward(client: &reqwest::Client, url: &str, req: Request<Body>) -> Res
         h.extend(rheaders);
     }
     resp.body(body).unwrap()
+}
+
+// Phase 4 chunk P: Synapse read-only views for the phone PWA.
+//
+// `/api/synapse/status`  — is the worker running, on what port, what's its PID
+// `/api/synapse/peers`   — current discovered-on-LAN peer list
+// `/api/synapse/sessions` — live count of authenticated host connections
+//
+// The phone consumes these to render its read-only Synapse tab. We don't
+// expose start/stop/restart from the LAN — the phone is for monitoring,
+// not control, and gating mutations behind the desktop UI keeps the
+// surface area small.
+async fn synapse_status(State(s): State<AppState>) -> impl IntoResponse {
+    Json(s.synapse.status().await)
+}
+
+async fn synapse_peers(State(s): State<AppState>) -> impl IntoResponse {
+    Json(s.synapse.list_peers().await)
+}
+
+async fn synapse_sessions(State(_): State<AppState>) -> impl IntoResponse {
+    let count = crate::auth_proxy::ACTIVE_SESSIONS.load(std::sync::atomic::Ordering::Relaxed);
+    Json(serde_json::json!({ "count": count }))
+}
+
+/// Phase 4 chunk R: Prometheus exposition format. Plain text, one metric
+/// per line per series, with HELP/TYPE preambles. The contract is small
+/// and stable: rename a metric here = breaking change for anyone
+/// scraping it, so we treat field names as part of the public API.
+async fn prometheus_metrics(State(s): State<AppState>) -> impl IntoResponse {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    // Worker mode + active sessions.
+    let synapse_status = s.synapse.status().await;
+    let _ = writeln!(
+        out,
+        "# HELP localmind_synapse_worker_running 1 if the Synapse worker is currently spawned, 0 otherwise."
+    );
+    let _ = writeln!(out, "# TYPE localmind_synapse_worker_running gauge");
+    let _ = writeln!(
+        out,
+        "localmind_synapse_worker_running {}",
+        if synapse_status.running { 1 } else { 0 }
+    );
+
+    let _ = writeln!(
+        out,
+        "# HELP localmind_synapse_worker_port TCP port of the worker's auth proxy (0 when not running)."
+    );
+    let _ = writeln!(out, "# TYPE localmind_synapse_worker_port gauge");
+    let _ = writeln!(
+        out,
+        "localmind_synapse_worker_port {}",
+        if synapse_status.running {
+            synapse_status.port
+        } else {
+            0
+        }
+    );
+
+    let active = crate::auth_proxy::ACTIVE_SESSIONS.load(std::sync::atomic::Ordering::Relaxed);
+    let _ = writeln!(
+        out,
+        "# HELP localmind_synapse_active_sessions Authenticated host connections currently held by the auth proxy."
+    );
+    let _ = writeln!(out, "# TYPE localmind_synapse_active_sessions gauge");
+    let _ = writeln!(out, "localmind_synapse_active_sessions {active}");
+
+    // Discovered peers, with a label per verification state. Useful to
+    // alert on "discovered: yes, verified: no" — that's "your beacon
+    // signing or token-pasting workflow has drifted."
+    let peers = s.synapse.list_peers().await;
+    let verified_count = peers.iter().filter(|p| p.verified).count();
+    let unverified_count = peers.len() - verified_count;
+    let _ = writeln!(
+        out,
+        "# HELP localmind_synapse_peers Discovered peers on the LAN, broken down by verification state."
+    );
+    let _ = writeln!(out, "# TYPE localmind_synapse_peers gauge");
+    let _ = writeln!(
+        out,
+        "localmind_synapse_peers{{verified=\"true\"}} {verified_count}"
+    );
+    let _ = writeln!(
+        out,
+        "localmind_synapse_peers{{verified=\"false\"}} {unverified_count}"
+    );
+
+    // llama-server status, for quick "is anything loaded" checks.
+    let llama_status = s.llama.status().await;
+    let _ = writeln!(
+        out,
+        "# HELP localmind_llama_chat_running 1 if a chat model is currently loaded, 0 otherwise."
+    );
+    let _ = writeln!(out, "# TYPE localmind_llama_chat_running gauge");
+    let _ = writeln!(
+        out,
+        "localmind_llama_chat_running {}",
+        if llama_status.running { 1 } else { 0 }
+    );
+
+    let _ = writeln!(
+        out,
+        "# HELP localmind_llama_embed_running 1 if an embedding model is currently loaded, 0 otherwise."
+    );
+    let _ = writeln!(out, "# TYPE localmind_llama_embed_running gauge");
+    let _ = writeln!(
+        out,
+        "localmind_llama_embed_running {}",
+        if llama_status.embedding_running { 1 } else { 0 }
+    );
+
+    (
+        StatusCode::OK,
+        [("content-type", "text/plain; version=0.0.4")],
+        out,
+    )
 }

--- a/src-tauri/src/synapse.rs
+++ b/src-tauri/src/synapse.rs
@@ -45,6 +45,12 @@ const BEACON_MAGIC: &str = "localmind-synapse/1";
 /// type (in `SignedBeacon`) so verification can canonicalize the body bytes
 /// independently of the JSON field order. Keeping the body stable means we
 /// can add fields later without breaking signatures across versions.
+///
+/// Phase 4 chunk J: hardware fields (vram_gb, accelerator_kind) so the host
+/// can show real per-worker capacity in the marketplace and Synapse UI
+/// instead of the 4-GB-per-peer guess from Phase 3. All hardware fields are
+/// optional so older workers (no fields → None) keep working with no
+/// special-casing on the host side.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct BeaconPayload {
     /// Magic string so we can ignore stray UDP traffic on this port.
@@ -54,6 +60,23 @@ struct BeaconPayload {
     hostname: String,
     port: u16,
     version: String,
+    /// VRAM (or unified memory share) advertised in GB, rounded to 1 decimal.
+    /// Hosts use this to size their Synapse-cluster memory budget.
+    #[serde(default)]
+    vram_gb: Option<f32>,
+    /// Short tag for the accelerator kind: "apple", "nvidia", "amd",
+    /// "intel-arc", "cpu". UI uses it to pick an icon.
+    #[serde(default)]
+    accelerator_kind: Option<String>,
+    /// Friendly accelerator description ("Apple M1 Pro", "NVIDIA RTX 5070 Ti")
+    /// for the chip subtitle.
+    #[serde(default)]
+    accelerator_name: Option<String>,
+    /// Phase 4 chunk N: SHA-256 hex fingerprint of the worker's TLS cert.
+    /// Rides inside the HMAC-signed body so a man-in-the-middle can't
+    /// substitute their own fingerprint without invalidating the signature.
+    #[serde(default)]
+    cert_fingerprint: Option<String>,
 }
 
 /// On-the-wire envelope. `body` carries the user-visible fields; `hmac` is
@@ -93,6 +116,15 @@ pub struct SynapsePeer {
     /// see this as false — they can still add the peer manually, the dialog
     /// captures the token, and once stored verification flips on.
     pub verified: bool,
+    /// Phase 4 chunk J: hardware advertised in the beacon. Pre-Phase-4
+    /// workers leave these as None.
+    pub vram_gb: Option<f32>,
+    pub accelerator_kind: Option<String>,
+    pub accelerator_name: Option<String>,
+    /// Phase 4 chunk N: SHA-256 fingerprint of the worker's TLS cert.
+    /// The host pins this on first pair so a same-IP attacker can't
+    /// impersonate the worker even with the token.
+    pub cert_fingerprint: Option<String>,
 }
 
 struct WorkerHandle {
@@ -450,6 +482,16 @@ impl SynapseState {
                             // authenticated channel; mDNS-only peers stay
                             // unverified in the UI.
                             verified: false,
+                            // mDNS path also doesn't carry the new chunk-J
+                            // hardware fields — those ride only on the
+                            // signed beacon. The same peer typically
+                            // surfaces via both routes; list_peers dedupes
+                            // by endpoint and keeps the beacon's richer
+                            // metadata.
+                            vram_gb: None,
+                            accelerator_kind: None,
+                            accelerator_name: None,
+                            cert_fingerprint: None,
                         };
                         me.peers.lock().await.insert(id, peer.clone());
                         let _ = app.emit("synapse:peer-added", &peer);
@@ -587,12 +629,65 @@ async fn spawn_beacon(app: AppHandle, port: u16) -> Result<JoinHandle<()>> {
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "localmind".to_string());
     let id = format!("beacon:{}-{}", sanitize_dns_label(&raw_host), port);
+    // Phase 4 chunk J: snapshot hardware once at start. We don't refresh
+    // mid-session — VRAM doesn't change, and re-detecting on every tick
+    // would be wasted CPU. If a user moves models around the host's
+    // marketplace re-renders on the next set_known_tokens push anyway.
+    let hw = crate::hardware::detect();
+    let (acc_kind, acc_name, vram_gb) = match &hw.accelerator {
+        crate::hardware::Accelerator::AppleSilicon {
+            chip,
+            unified_memory_gb,
+        } => (
+            Some("apple".to_string()),
+            Some(format!("Apple {chip}")),
+            // Apple unified memory: budget the GPU usefully gets is
+            // ~75% before macOS pushes back hard. Match what the host
+            // marketplace heuristic uses for self.
+            Some((*unified_memory_gb as f32) * 0.75),
+        ),
+        crate::hardware::Accelerator::Nvidia { name, vram_gb, .. } => (
+            Some("nvidia".to_string()),
+            Some(name.clone()),
+            Some(*vram_gb as f32),
+        ),
+        crate::hardware::Accelerator::Amd { name, vram_gb } => (
+            Some("amd".to_string()),
+            Some(name.clone()),
+            Some(*vram_gb as f32),
+        ),
+        crate::hardware::Accelerator::IntelArc { name } => {
+            (Some("intel-arc".to_string()), Some(name.clone()), None)
+        }
+        crate::hardware::Accelerator::Cpu => (
+            Some("cpu".to_string()),
+            Some(hw.cpu_name.clone()),
+            // CPU-only: advertise system RAM minus a 4 GB OS reserve so
+            // the host's budget calc treats this peer like a CPU node.
+            Some(((hw.total_memory_gb - 4.0).max(0.0)) as f32),
+        ),
+    };
+    // Phase 4 chunk N: include the cert fingerprint so paired hosts can
+    // pin TLS verification on next connect. Best-effort — if cert load
+    // fails (read-only data dir, e.g.), advertise None and the host falls
+    // back to TOFU.
+    let cert_fingerprint = match crate::synapse_tls::load_or_create_cert() {
+        Ok((_, _, fp)) => Some(fp),
+        Err(e) => {
+            eprintln!("synapse: TLS cert load failed: {e}");
+            None
+        }
+    };
     let payload = BeaconPayload {
         magic: BEACON_MAGIC.to_string(),
         id,
         hostname: raw_host,
         port,
         version: env!("CARGO_PKG_VERSION").to_string(),
+        vram_gb,
+        accelerator_kind: acc_kind,
+        accelerator_name: acc_name,
+        cert_fingerprint,
     };
     // Phase 3 chunk E: HMAC-sign the canonical body. Hosts that have our
     // token verify; hosts that don't see us as unverified. The signature
@@ -704,6 +799,10 @@ async fn run_beacon_listener(state: Arc<SynapseState>, app: AppHandle, sock: Udp
             port: payload.port,
             endpoint,
             verified,
+            vram_gb: payload.vram_gb,
+            accelerator_kind: payload.accelerator_kind.clone(),
+            accelerator_name: payload.accelerator_name.clone(),
+            cert_fingerprint: payload.cert_fingerprint.clone(),
         };
 
         // Insert or refresh. Only fire peer-added on first sight; refreshes

--- a/src-tauri/src/synapse_tls.rs
+++ b/src-tauri/src/synapse_tls.rs
@@ -1,0 +1,184 @@
+// Phase 4 chunk N: TLS for the Synapse auth proxy.
+//
+// Each worker owns a self-signed cert pair persisted at
+// `<data_dir>/synapse-cert.pem` + `synapse-key.pem`. The cert's SHA-256
+// fingerprint rides in the beacon body (so it's HMAC-protected too) and
+// gets pinned by the host on first pairing.
+//
+// The handshake stack:
+//
+//     TCP ─▶ rustls (TLS 1.3, custom verifier on host) ─▶ length-prefixed JSON
+//
+// Custom verifier rather than full PKI because we're not buying certs from a
+// CA — the security promise is "you trust this fingerprint, exactly once,
+// when you paste the token." Rustls' default verifier would reject every
+// connection because none of these certs chain to a public root.
+
+use crate::config;
+use anyhow::{anyhow, Context, Result};
+use data_encoding::HEXLOWER;
+use rcgen::{generate_simple_self_signed, CertifiedKey};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
+use rustls::server::WebPkiClientVerifier;
+use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, ServerConfig, SignatureScheme};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::sync::Arc;
+
+/// Load the worker's cert + key, generating them on first call. Idempotent:
+/// reads the same files on every subsequent call. Returns the parsed DER
+/// bundle along with a SHA-256 fingerprint of the leaf cert (lowercase hex,
+/// no separators).
+pub fn load_or_create_cert(
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>, String)> {
+    let cert_path = config::synapse_cert_path();
+    let key_path = config::synapse_key_path();
+
+    if !cert_path.exists() || !key_path.exists() {
+        // Subject altname covers the literal hostname AND localhost — the
+        // host always reaches us via the beacon-advertised IP, but having
+        // both in the cert SANs makes manual `openssl s_client -connect`
+        // testing easier.
+        let host = hostname::get()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "localmind".to_string());
+        let CertifiedKey { cert, key_pair } =
+            generate_simple_self_signed(vec![host.clone(), "localhost".into()])
+                .map_err(|e| anyhow!("generate cert: {e}"))?;
+        if let Some(parent) = cert_path.parent() {
+            fs::create_dir_all(parent).context("creating cert dir")?;
+        }
+        fs::write(&cert_path, cert.pem()).context("writing cert pem")?;
+        fs::write(&key_path, key_pair.serialize_pem()).context("writing key pem")?;
+    }
+
+    let cert_pem = fs::read(&cert_path).context("reading cert")?;
+    let key_pem = fs::read(&key_path).context("reading key")?;
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut cert_pem.as_slice())
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| anyhow!("parse cert: {e}"))?;
+    if certs.is_empty() {
+        return Err(anyhow!("cert file is empty"));
+    }
+    let key = rustls_pemfile::private_key(&mut key_pem.as_slice())
+        .map_err(|e| anyhow!("parse key: {e}"))?
+        .ok_or_else(|| anyhow!("no private key in key file"))?;
+
+    let fingerprint = fingerprint_of(&certs[0]);
+    Ok((certs, key, fingerprint))
+}
+
+/// SHA-256 of the leaf cert's DER, lowercase hex with no separators. We use
+/// hex (not base32) to match the `openssl x509 -fingerprint -sha256`
+/// canonical format users see when sanity-checking a cert manually.
+pub fn fingerprint_of(cert: &CertificateDer) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(cert.as_ref());
+    HEXLOWER.encode(&hasher.finalize())
+}
+
+/// Build a rustls ServerConfig for the worker auth proxy. No client auth
+/// at the TLS layer — the application-layer handshake already token-gates
+/// every connection.
+pub fn server_config(
+    certs: Vec<CertificateDer<'static>>,
+    key: PrivateKeyDer<'static>,
+) -> Result<ServerConfig> {
+    // We reject client certs entirely; build an empty store.
+    let _empty_roots = RootCertStore::empty();
+    let _no_client_verifier = WebPkiClientVerifier::no_client_auth();
+    ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| anyhow!("server tls config: {e}"))
+}
+
+/// Build a rustls ClientConfig that pins exactly one cert fingerprint. Used
+/// by `host_proxy` when dialing a worker — the host has the worker's
+/// fingerprint from the verified beacon and refuses anything else.
+pub fn client_config_pinning(expected_fingerprint_hex: String) -> Result<ClientConfig> {
+    let verifier = Arc::new(PinnedFingerprintVerifier {
+        expected: expected_fingerprint_hex.to_ascii_lowercase(),
+    });
+    let cfg = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth();
+    Ok(cfg)
+}
+
+/// Custom rustls verifier: accept exactly one cert, identified by SHA-256
+/// fingerprint. Rejects anything else. The "danger" knob in rustls expects
+/// a verifier that says yes to *something*; ours says yes to exactly the
+/// pinned cert and no to literally everything else.
+#[derive(Debug)]
+struct PinnedFingerprintVerifier {
+    expected: String,
+}
+
+impl ServerCertVerifier for PinnedFingerprintVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        // Empty expected fingerprint = TOFU mode. Used when the host has a
+        // token but no fingerprint yet (typically: paired with a Phase 3
+        // worker, or paired before re-pairing via the dialog). The token
+        // gate at the application layer is the real defense in this mode.
+        if self.expected.is_empty() {
+            return Ok(ServerCertVerified::assertion());
+        }
+        let actual = fingerprint_of(end_entity);
+        if actual == self.expected {
+            Ok(ServerCertVerified::assertion())
+        } else {
+            // Surface expected vs actual in the error so logs are
+            // diagnostic without leaking secrets — fingerprints are
+            // already public.
+            Err(rustls::Error::General(format!(
+                "cert fingerprint mismatch: expected {}, got {actual}",
+                self.expected
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        // We pin by fingerprint, not by chain — the signature is whatever
+        // the matched cert produced; trust by definition.
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        // Match what rcgen produces by default (ECDSA P-256) plus the
+        // common alternatives so cert rotation doesn't require code change.
+        vec![
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::ED25519,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+        ]
+    }
+}

--- a/src-tauri/src/synapse_tls.rs
+++ b/src-tauri/src/synapse_tls.rs
@@ -25,6 +25,17 @@ use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, ServerConfig, S
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::sync::Arc;
+use std::sync::Once;
+
+/// Belt-and-suspenders for the rustls crypto provider. `lib::run()` calls
+/// `install_default` at startup, but if any TLS path is reached before that
+/// (or in a test that bypasses `run()`), this guarantees a provider is set.
+fn ensure_crypto_provider() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
 
 /// Load the worker's cert + key, generating them on first call. Idempotent:
 /// reads the same files on every subsequent call. Returns the parsed DER
@@ -86,6 +97,7 @@ pub fn server_config(
     certs: Vec<CertificateDer<'static>>,
     key: PrivateKeyDer<'static>,
 ) -> Result<ServerConfig> {
+    ensure_crypto_provider();
     // We reject client certs entirely; build an empty store.
     let _empty_roots = RootCertStore::empty();
     let _no_client_verifier = WebPkiClientVerifier::no_client_auth();
@@ -99,6 +111,7 @@ pub fn server_config(
 /// by `host_proxy` when dialing a worker — the host has the worker's
 /// fingerprint from the verified beacon and refuses anything else.
 pub fn client_config_pinning(expected_fingerprint_hex: String) -> Result<ClientConfig> {
+    ensure_crypto_provider();
     let verifier = Arc::new(PinnedFingerprintVerifier {
         expected: expected_fingerprint_hex.to_ascii_lowercase(),
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,7 @@ function App() {
         {!remote && view === "models" && <Models />}
         {!remote && view === "knowledge" && <Knowledge />}
         {!remote && view === "image" && <ImageGen />}
-        {!remote && view === "synapse" && <Synapse />}
+        {view === "synapse" && <Synapse />}
         {view === "settings" && <Settings />}
       </main>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -70,7 +70,8 @@ export function Sidebar({
         {!remote && <NavItem icon={<Boxes size={15} />} label="My models" active={view === "models"} onClick={onPick(() => setView("models"))} />}
         {!remote && <NavItem icon={<BookOpen size={15} />} label="Knowledge" active={view === "knowledge"} onClick={onPick(() => setView("knowledge"))} />}
         {!remote && <NavItem icon={<ImageIcon size={15} />} label="Images" active={view === "image"} onClick={onPick(() => setView("image"))} />}
-        {!remote && <NavItem icon={<Network size={15} />} label="Synapse" active={view === "synapse"} onClick={onPick(() => setView("synapse"))} />}
+        {/* Phase 4 chunk P: Synapse is now read-only available on phone too. */}
+        <NavItem icon={<Network size={15} />} label="Synapse" active={view === "synapse"} onClick={onPick(() => setView("synapse"))} />
         <NavItem icon={<SettingsIcon size={15} />} label="Settings" active={view === "settings"} onClick={onPick(() => setView("settings"))} />
       </nav>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -57,6 +57,27 @@ export async function remoteStatus(): Promise<LlamaStatus> {
   return res.json();
 }
 
+/// Phase 4 chunk P: read-only Synapse fetchers for the phone PWA. Always
+/// hit the paired desktop's LAN API — there's no desktop equivalent
+/// because desktop already has Tauri-IPC versions on `api`. Returning
+/// nullable so a transient LAN hiccup is visible (state goes empty)
+/// rather than throwing into an unhandled-promise hole.
+async function lanGet<T>(path: string): Promise<T> {
+  const c = connection();
+  if (!c) throw new Error("not connected");
+  const res = await fetch(`${c.url.replace(/\/+$/, "")}${path}`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`${path}: ${res.status}`);
+  return res.json();
+}
+
+export const remoteSynapse = {
+  status: () => lanGet<{ running: boolean; port: number; pid: number | null }>("/api/synapse/status"),
+  peers: () => lanGet<import("./types").SynapsePeer[]>("/api/synapse/peers"),
+  sessions: () => lanGet<{ count: number }>("/api/synapse/sessions"),
+};
+
 async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   if (isTauri()) {
     const { invoke } = await import("@tauri-apps/api/core");
@@ -118,6 +139,7 @@ export const api = {
   rotateSynapseToken: () => invoke<string>("rotate_synapse_token"),
   setKnownSynapseTokens: (tokens: Record<string, string>) =>
     invoke<void>("set_known_synapse_tokens", { tokens }),
+  synapseActiveSessions: () => invoke<number>("synapse_active_sessions"),
 };
 
 export type ChatContentPart =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,10 @@ export interface SynapseWorker {
    *  weight set, the host passes `--tensor-split` so layers split by ratio
    *  instead of evenly. Undefined keeps llama.cpp's default heuristic. */
   weight?: number;
+  /** Phase 4 chunk N: SHA-256 hex fingerprint pinned for TLS verification.
+   *  Captured from the worker's HMAC-verified beacon at pair time;
+   *  undefined means TOFU (any cert accepted, token still gates). */
+  certFingerprint?: string;
 }
 
 export interface LlamaSettings {
@@ -105,6 +109,15 @@ export interface SynapsePeer {
    *  Hosts who haven't paired yet always see false; pair via the dialog and
    *  the next set_known_synapse_tokens call flips this on the cached entry. */
   verified: boolean;
+  /** Phase 4 chunk J: hardware advertised in the beacon. Pre-Phase-4
+   *  workers leave these undefined; treat that as "unknown, fall back to
+   *  conservative defaults". */
+  vramGb?: number;
+  acceleratorKind?: "apple" | "nvidia" | "amd" | "intel-arc" | "cpu";
+  acceleratorName?: string;
+  /** Phase 4 chunk N: SHA-256 hex fingerprint of the worker's TLS cert.
+   *  Rides inside the HMAC-signed beacon body. UI captures it on pair. */
+  certFingerprint?: string;
 }
 
 /** synapse:metrics event payload — emitted by the chat llama-server's stderr
@@ -121,6 +134,14 @@ export interface SynapseRtt {
   endpoint: string;
   rttMs: number;
   ok: boolean;
+  ts: number;
+}
+
+/** synapse:cluster-layout event payload — emitted once per model load,
+ *  containing one entry per device that received layer tensors. Built
+ *  from `load_tensors: <DEVICE> model buffer size = X MiB` lines. */
+export interface SynapseClusterLayout {
+  devices: { device: string; mb: number }[];
   ts: number;
 }
 

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { api, listen } from "../lib/api";
 import { useApp } from "../lib/store";
-import type { HardwareInfo, ModelDownloadProgress, ModelListing } from "../lib/types";
+import type { HardwareInfo, ModelDownloadProgress, ModelListing, SynapsePeer } from "../lib/types";
 import { formatBytes, formatCompact } from "../lib/util";
 
 const SUGGESTED = [
@@ -23,16 +23,57 @@ const SUGGESTED = [
   { label: "Vision (LLaVA)", q: "llava-1.6 GGUF" },
 ];
 
+/** Phase 4 chunk M: reverse-search filter modes.
+ *  - "all": no filter (default)
+ *  - "fits-host": only show files loadable on the host alone
+ *  - "fits-cluster": only show files loadable across host + Synapse
+ *  - "needs-synapse": only show files that *require* Synapse to load
+ *      (won't fit on host alone but fit cluster). The most useful mode
+ *      when you've just paired a worker and want to know what it
+ *      newly unlocked.
+ */
+type FitFilter = "all" | "fits-host" | "fits-cluster" | "needs-synapse";
+
 export function Marketplace() {
   const [query, setQuery] = useState("llama-3.1-8b-instruct GGUF");
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<ModelListing[]>([]);
+  const [fitFilter, setFitFilter] = useState<FitFilter>("all");
   const { installed, setInstalled, downloads, setDownload, clearDownload, hardware, synapse } = useApp();
-  // peerCount = workers the user has added with a token (i.e. usable). We
-  // don't include unverified beacon peers in the Synapse budget — those
-  // can't actually receive layers until the user pairs.
-  const peerCount = synapse.workers.filter((w) => !!w.token).length;
-  const budget = useMemo(() => memoryBudgetGb(hardware, peerCount), [hardware, peerCount]);
+  // Phase 4 chunk J: pull real per-peer VRAM from the discovered-peers
+  // cache so the marketplace budget reflects what's actually on the LAN
+  // instead of the conservative 4-GB-per-peer fallback. We resolve token-
+  // paired workers (the ones the user can actually use) by endpoint
+  // against the live peer list.
+  const [peers, setPeers] = useState<Record<string, SynapsePeer>>({});
+  useEffect(() => {
+    api.synapseListPeers()
+      .then((list) => {
+        const next: Record<string, SynapsePeer> = {};
+        for (const p of list) next[p.endpoint] = p;
+        setPeers(next);
+      })
+      .catch(() => {});
+    let cancelled = false;
+    const subs: Array<() => void> = [];
+    listen<SynapsePeer>("synapse:peer-added", (p) => {
+      setPeers((prev) => ({ ...prev, [p.endpoint]: p }));
+    }).then((un) => { if (cancelled) un(); else subs.push(un); });
+    return () => {
+      cancelled = true;
+      subs.forEach((un) => un());
+    };
+  }, []);
+  // peerVrams: per-paired-worker VRAM in GB. Falls back to 4 (the chunk-H
+  // conservative default) when the worker hasn't broadcast hardware info
+  // yet — typically pre-Phase-4 builds.
+  const peerVrams = synapse.workers
+    .filter((w) => !!w.token)
+    .map((w) => peers[w.endpoint]?.vramGb ?? 4);
+  const budget = useMemo(
+    () => memoryBudgetGb(hardware, peerVrams),
+    [hardware, peerVrams.join(",")],  // primitive-array dep avoids object-identity churn
+  );
 
   useEffect(() => {
     listen<ModelDownloadProgress>("model:progress", (p) => {
@@ -91,6 +132,37 @@ export function Marketplace() {
             </button>
           ))}
         </div>
+
+        {/* Phase 4 chunk M: fit filters. Only show the cluster-aware
+            buckets when the user has a Synapse cluster — otherwise
+            "fits cluster" and "fits host" are identical and confusing. */}
+        <div className="flex flex-wrap gap-2 mt-2 items-center">
+          <span className="text-[11px] uppercase tracking-wider text-[var(--color-text-subtle)]">Filter</span>
+          {(
+            [
+              { v: "all" as const, label: "All" },
+              { v: "fits-host" as const, label: "Fits this machine" },
+              ...(peerVrams.length > 0
+                ? [
+                    { v: "fits-cluster" as const, label: "Fits cluster" },
+                    { v: "needs-synapse" as const, label: "Unlocked by Synapse" },
+                  ]
+                : []),
+            ]
+          ).map((b) => (
+            <button
+              key={b.v}
+              onClick={() => setFitFilter(b.v)}
+              className={`text-xs px-2.5 py-1 rounded-full border ${
+                fitFilter === b.v
+                  ? "border-[var(--color-accent)] text-[var(--color-text)]"
+                  : "border-[var(--color-border)] text-[var(--color-text-muted)] hover:border-[var(--color-accent)]/60"
+              }`}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
       </header>
 
       <div className="flex-1 overflow-y-auto px-5 py-4">
@@ -100,14 +172,14 @@ export function Marketplace() {
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-            {results.map((m) => (
+            {applyFitFilter(results, fitFilter, budget).map((m) => (
               <ModelCard
                 key={m.id}
                 listing={m}
                 installed={installed}
                 downloads={downloads}
                 budget={budget}
-                peerCount={peerCount}
+                peerCount={peerVrams.length}
               />
             ))}
           </div>
@@ -257,18 +329,15 @@ function ModelCard({
   );
 }
 
-/** Phase 3 chunk H: compute the available memory budget for loading a model.
- *  Returns { hostGb, synapseGb } so the marketplace can show the user how
- *  Synapse extends their reach. We deliberately don't try to be exact about
- *  KV-cache or activations — the budget is a guidance, not a guarantee, and
- *  keeping the heuristic simple beats getting it precisely wrong.
+/** Phase 3 chunk H + Phase 4 chunk J: compute the available memory budget
+ *  for loading a model. Returns { hostGb, synapseGb } so the marketplace
+ *  can show the user how Synapse extends their reach.
  *
- *  Host budget = total RAM (Apple Silicon: unified memory) or VRAM (NVIDIA/AMD).
- *  Synapse budget = host + sum of detected peers, with 4 GB assumed per peer
- *  since beacon doesn't carry VRAM yet (chunk 2c, deferred). Conservative: a
- *  paired RTX 5070 Ti has 16 GB but we assume 4, so the badge under-promises.
- */
-function memoryBudgetGb(hw: HardwareInfo | null, peerCount: number) {
+ *  Host budget = total RAM × 0.75 (Apple Silicon: unified memory) or VRAM
+ *  (NVIDIA/AMD).
+ *  Synapse budget = host + sum of advertised peer VRAM. Pre-Phase-4 peers
+ *  pass 4 GB as a fallback so they still contribute conservatively. */
+function memoryBudgetGb(hw: HardwareInfo | null, peerVrams: number[]) {
   if (!hw) return { hostGb: 0, synapseGb: 0 };
   const acc = hw.accelerator;
   const hostGb = (() => {
@@ -288,8 +357,8 @@ function memoryBudgetGb(hw: HardwareInfo | null, peerCount: number) {
         return Math.max(0, Math.floor(hw.totalMemoryGb - 4));
     }
   })();
-  const synapseGb = hostGb + peerCount * 4;
-  return { hostGb, synapseGb };
+  const peerSum = peerVrams.reduce((a, b) => a + b, 0);
+  return { hostGb, synapseGb: hostGb + peerSum };
 }
 
 /** Estimated bytes-on-GPU needed to actually load a GGUF. The file size is
@@ -297,6 +366,52 @@ function memoryBudgetGb(hw: HardwareInfo | null, peerCount: number) {
  *  by 1.15 to keep the badge from being aggressively optimistic. */
 function fitGb(fileBytes: number) {
   return (fileBytes * 1.15) / 1024 ** 3;
+}
+
+/** Phase 4 chunk M: apply the fit filter and sort the surviving listings.
+ *  A model survives if at least one of its files matches the filter (since
+ *  multi-quant repos commonly have a small variant that fits + a big one
+ *  that doesn't). We sort biggest-fitting-file-first per listing so the
+ *  user sees impressive models at the top of "fits cluster" rather than
+ *  having to scroll through trivially-small ones first. */
+function applyFitFilter(
+  listings: ModelListing[],
+  filter: FitFilter,
+  budget: { hostGb: number; synapseGb: number },
+): ModelListing[] {
+  if (filter === "all") return listings;
+  const matchesFile = (bytes: number) => {
+    const need = fitGb(bytes);
+    switch (filter) {
+      case "fits-host":
+        return budget.hostGb > 0 && need <= budget.hostGb;
+      case "fits-cluster":
+        return budget.synapseGb > 0 && need <= budget.synapseGb;
+      case "needs-synapse":
+        return (
+          budget.hostGb > 0 &&
+          need > budget.hostGb &&
+          budget.synapseGb > 0 &&
+          need <= budget.synapseGb
+        );
+      default:
+        return true;
+    }
+  };
+  const surviving = listings.filter((l) =>
+    l.files.some((f) => matchesFile(f.sizeBytes)),
+  );
+  // Sort by largest matching file: it's a stand-in for "most ambitious
+  // model that fits" and matches the mental model of someone exploring
+  // their cluster's headroom.
+  return [...surviving].sort((a, b) => {
+    const maxFit = (l: ModelListing) =>
+      Math.max(
+        ...l.files.filter((f) => matchesFile(f.sizeBytes)).map((f) => f.sizeBytes),
+        0,
+      );
+    return maxFit(b) - maxFit(a);
+  });
 }
 
 function pickDefault(l: ModelListing) {

--- a/src/pages/Synapse.tsx
+++ b/src/pages/Synapse.tsx
@@ -320,6 +320,14 @@ export function Synapse() {
 
   function commitWorkersText(text: string) {
     setWorkersText(text);
+    // Preserve weight + certFingerprint for any endpoint that already exists
+    // in the store. The textarea only carries `endpoint|token` — without this
+    // merge, every keystroke in the bulk-import textarea silently wiped the
+    // pinned cert and the layer-split weight, which is the path that made
+    // the second model load skip the worker (no fingerprint → TOFU; no
+    // weight → backend used a default that didn't match the UI).
+    const existingByEndpoint: Record<string, SynapseWorker> = {};
+    for (const w of synapse.workers) existingByEndpoint[w.endpoint] = w;
     const parsed: SynapseWorker[] = text
       .split(/[,\n]/)
       .map((s) => s.trim())
@@ -330,10 +338,14 @@ export function Synapse() {
         // entirely — host_proxy will fail-fast at load time with a clear
         // "no token configured for X" error.
         const sep = line.indexOf("|");
-        if (sep === -1) return { endpoint: line, token: "" };
+        const endpoint = sep === -1 ? line : line.slice(0, sep).trim();
+        const token = sep === -1 ? "" : line.slice(sep + 1).trim();
+        const prev = existingByEndpoint[endpoint];
         return {
-          endpoint: line.slice(0, sep).trim(),
-          token: line.slice(sep + 1).trim(),
+          endpoint,
+          token,
+          weight: prev?.weight,
+          certFingerprint: prev?.certFingerprint,
         };
       });
     setSynapseWorkers(parsed);
@@ -404,15 +416,6 @@ export function Synapse() {
     const next = synapse.workers.filter((w) => w.endpoint !== endpoint);
     setSynapseWorkers(next);
     setWorkersText(workersToText(next));
-  }
-
-  // Phase 3 chunk G: update one worker's weight in the layer split. Stored
-  // as 0–1 in the SynapseWorker type but presented as 0–100 in the UI.
-  function setWorkerWeight(endpoint: string, value01: number) {
-    const next = synapse.workers.map((w) =>
-      w.endpoint === endpoint ? { ...w, weight: value01 } : w,
-    );
-    setSynapseWorkers(next);
   }
 
   // Reset every weight, including host's, back to "use llama.cpp default".
@@ -880,20 +883,39 @@ export function Synapse() {
           {/* Layer split (--tensor-split). Lets users override llama.cpp's
               even-split default — important when host and worker have very
               different compute (e.g. M1 Pro host + 4090 worker → most layers
-              should land on the 4090). Hidden in <details> so the common
-              case (default split) doesn't get cluttered with sliders. */}
+              should land on the 4090). Donut + numeric % inputs that always
+              sum to 100, so what the user types is what gets loaded. */}
           {synapse.workers.length > 0 && (() => {
-            // Compute display percentages from the explicit weights. Sliders
-            // bind to raw 0–100 values; we do the normalization to a sum of
-            // 1.0 in the backend when building --tensor-split.
-            const hostW = synapse.hostWeight ?? 0;
-            const workerWs = synapse.workers.map((w) => w.weight ?? 0);
-            const total = hostW + workerWs.reduce((a, b) => a + b, 0);
-            const pct = (v: number) =>
-              total > 0 ? Math.round((v / total) * 100) : 0;
             const anyExplicit =
               synapse.hostWeight !== undefined ||
               synapse.workers.some((w) => w.weight !== undefined);
+            // Build the array of percentages the editor binds to. When no
+            // weights are set, show an even split as the implicit default
+            // — matches llama.cpp's behavior when --tensor-split is omitted.
+            const n = synapse.workers.length + 1;
+            const rawWeights = [
+              synapse.hostWeight ?? 1 / n,
+              ...synapse.workers.map((w) => w.weight ?? 1 / n),
+            ];
+            const sum = rawWeights.reduce((a, b) => a + b, 0) || 1;
+            const pcts = rawWeights.map((w) => (w / sum) * 100);
+            const labels = [
+              "This machine (host)",
+              ...synapse.workers.map((w) => w.endpoint),
+            ];
+
+            const applyPcts = (next: number[]) => {
+              // Backend already normalizes, but we store a sum-to-1 fraction
+              // so the percentage we showed is exactly the percentage that
+              // gets loaded. No silent re-scaling between UI and inference.
+              setSynapseHostWeight(next[0] / 100);
+              const w2 = synapse.workers.map((w, i) => ({
+                ...w,
+                weight: next[i + 1] / 100,
+              }));
+              setSynapseWorkers(w2);
+            };
+
             return (
               <details className="mt-4 group" open={anyExplicit}>
                 <summary className="text-xs text-[var(--color-text-muted)] cursor-pointer select-none hover:text-[var(--color-text)] flex items-center justify-between">
@@ -927,27 +949,17 @@ export function Synapse() {
                     )}
                   </span>
                 </summary>
-                <div className="mt-2 flex flex-col gap-2">
-                  <SplitSlider
-                    label="This machine (host)"
-                    value01={synapse.hostWeight ?? 0.5}
-                    pct={anyExplicit ? pct(hostW) : null}
-                    onChange={(v) => setSynapseHostWeight(v)}
+                <div className="mt-3">
+                  <SplitDonut
+                    labels={labels}
+                    pcts={pcts}
+                    onChange={applyPcts}
                   />
-                  {synapse.workers.map((w, i) => (
-                    <SplitSlider
-                      key={w.endpoint}
-                      label={w.endpoint}
-                      value01={w.weight ?? 0.5}
-                      pct={anyExplicit ? pct(workerWs[i]) : null}
-                      onChange={(v) => setWorkerWeight(w.endpoint, v)}
-                    />
-                  ))}
-                  <div className="text-[11px] text-[var(--color-text-subtle)] mt-1 leading-snug">
-                    Higher = more layers on that device. Values are normalized
-                    to a fraction; the actual layer count is rounded to the
-                    nearest integer at load time. Reset to fall back to
-                    llama.cpp's default heuristic.
+                  <div className="text-[11px] text-[var(--color-text-subtle)] mt-2 leading-snug">
+                    Editing one value rebalances the others proportionally
+                    so the total stays 100%. The actual layer count is
+                    rounded to the nearest integer at load time. Reset to
+                    fall back to llama.cpp's default heuristic.
                   </div>
                 </div>
               </details>
@@ -1079,39 +1091,184 @@ function Section({
   );
 }
 
-/// One row of the layer-split editor: label + slider + computed %. The slider
-/// binds to a raw 0–1 weight; normalization to a sum of 1 happens in the
-/// backend so the UI doesn't have to coordinate state across N rows.
-function SplitSlider({
-  label,
-  value01,
-  pct,
+/// Layer-split editor: donut chart + per-device numeric % inputs that always
+/// sum to 100. Editing one input redistributes the delta across the others
+/// proportionally to their current shares, so the user always sees the
+/// exact percentage that will be loaded.
+function SplitDonut({
+  labels,
+  pcts,
   onChange,
 }: {
-  label: string;
-  value01: number;
-  pct: number | null;
-  onChange: (v: number) => void;
+  labels: string[];
+  pcts: number[];
+  onChange: (next: number[]) => void;
 }) {
+  // Tailwind doesn't help here — we need real CSS color values for SVG
+  // strokes and the swatch dots. Picked a small, distinct palette that
+  // rotates if there are more devices than entries.
+  const palette = ["#6366f1", "#10b981", "#f59e0b", "#a855f7", "#ec4899", "#06b6d4"];
+  const colorAt = (i: number) => palette[i % palette.length];
+
+  // Local string state for the inputs so users can type freely (e.g.
+  // erase to empty before typing a new number) without React clobbering
+  // the input on every keystroke. We commit to the parent on blur/Enter.
+  const [drafts, setDrafts] = useState<string[]>(() => pcts.map((p) => p.toFixed(0)));
+  // Re-sync drafts when external pcts change (e.g. "suggest" or "reset"
+  // buttons rewrite the weights). Comparing length+rounded values keeps
+  // typing stable: a draft like "5" doesn't get clobbered by 5.0.
+  const pctsKey = pcts.map((p) => Math.round(p)).join(",");
+  useEffect(() => {
+    setDrafts(pcts.map((p) => Math.round(p).toString()));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pctsKey]);
+
+  function commit(idx: number, raw: string) {
+    const parsed = parseFloat(raw);
+    if (!Number.isFinite(parsed)) {
+      setDrafts(pcts.map((p) => Math.round(p).toString()));
+      return;
+    }
+    const next = rebalance(pcts, idx, parsed);
+    onChange(next);
+  }
+
+  // SVG donut geometry. 64 viewBox units = nice round numbers in path
+  // commands; CSS sizes the chart visually.
+  const size = 128;
+  const cx = 32;
+  const cy = 32;
+  const r = 24;
+  const stroke = 10;
+
+  let acc = 0;
+  const totalPct = pcts.reduce((a, b) => a + b, 0) || 100;
+  const arcs = pcts.map((p, i) => {
+    const start = acc;
+    acc += p;
+    const end = acc;
+    return { i, start, end, p };
+  });
+
   return (
-    <label className="grid grid-cols-[1fr_auto] items-center gap-2 text-xs">
-      <div className="flex items-center justify-between gap-2 min-w-0">
-        <span className="font-mono truncate">{label}</span>
-        <span className="text-[var(--color-text-subtle)] tabular-nums shrink-0">
-          {pct === null ? "auto" : `${pct}%`}
-        </span>
+    <div className="flex items-start gap-4 flex-wrap">
+      <svg
+        viewBox="0 0 64 64"
+        width={size}
+        height={size}
+        className="shrink-0"
+        role="img"
+        aria-label="Layer-split distribution donut"
+      >
+        {arcs.map(({ i, start, end, p }) => {
+          if (p <= 0) return null;
+          // Whole circle when one device owns everything — `arc` collapses
+          // to a zero-length path otherwise.
+          if (p >= totalPct - 0.001) {
+            return (
+              <circle
+                key={i}
+                cx={cx}
+                cy={cy}
+                r={r}
+                fill="none"
+                stroke={colorAt(i)}
+                strokeWidth={stroke}
+              />
+            );
+          }
+          const a0 = (start / totalPct) * 2 * Math.PI - Math.PI / 2;
+          const a1 = (end / totalPct) * 2 * Math.PI - Math.PI / 2;
+          const x0 = cx + r * Math.cos(a0);
+          const y0 = cy + r * Math.sin(a0);
+          const x1 = cx + r * Math.cos(a1);
+          const y1 = cy + r * Math.sin(a1);
+          const large = end - start > totalPct / 2 ? 1 : 0;
+          return (
+            <path
+              key={i}
+              d={`M ${x0.toFixed(3)} ${y0.toFixed(3)} A ${r} ${r} 0 ${large} 1 ${x1.toFixed(3)} ${y1.toFixed(3)}`}
+              fill="none"
+              stroke={colorAt(i)}
+              strokeWidth={stroke}
+              strokeLinecap="butt"
+            />
+          );
+        })}
+        <text
+          x={cx}
+          y={cy + 1}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          className="fill-[var(--color-text-muted)]"
+          fontSize="6"
+          fontFamily="ui-monospace, monospace"
+        >
+          100%
+        </text>
+      </svg>
+
+      <div className="flex flex-col gap-1.5 flex-1 min-w-[220px]">
+        {labels.map((label, i) => (
+          <div
+            key={label}
+            className="grid grid-cols-[auto_1fr_auto] items-center gap-2 text-xs"
+          >
+            <span
+              aria-hidden
+              className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+              style={{ backgroundColor: colorAt(i) }}
+            />
+            <span className="font-mono truncate">{label}</span>
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                min={0}
+                max={100}
+                step={1}
+                value={drafts[i] ?? ""}
+                onChange={(e) =>
+                  setDrafts((prev) => {
+                    const next = [...prev];
+                    next[i] = e.target.value;
+                    return next;
+                  })
+                }
+                onBlur={(e) => commit(i, e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    commit(i, (e.target as HTMLInputElement).value);
+                    (e.target as HTMLInputElement).blur();
+                  }
+                }}
+                className="w-12 text-right tabular-nums bg-[var(--color-panel-2)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs focus:outline-none focus:border-[var(--color-accent)]/60"
+                aria-label={`${label} percentage`}
+              />
+              <span className="text-[var(--color-text-subtle)]">%</span>
+            </div>
+          </div>
+        ))}
       </div>
-      <input
-        type="range"
-        min={0}
-        max={1}
-        step={0.01}
-        value={value01}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-[200px] accent-[var(--color-accent)]"
-      />
-    </label>
+    </div>
   );
+}
+
+/// Redistribute a delta across siblings so the array still sums to 100.
+/// The edited index becomes `clamp(0, raw, 100)`; everyone else scales
+/// proportionally to their old share. When the others are all zero we
+/// split the remainder evenly (otherwise the edit would be impossible
+/// to undo without typing into every other field).
+function rebalance(prev: number[], idx: number, raw: number): number[] {
+  const clamped = Math.max(0, Math.min(100, raw));
+  if (prev.length === 1) return [100];
+  const remaining = 100 - clamped;
+  const oldOthersSum = prev.reduce((a, b, i) => (i === idx ? a : a + b), 0);
+  if (oldOthersSum <= 0) {
+    const each = remaining / (prev.length - 1);
+    return prev.map((_, i) => (i === idx ? clamped : each));
+  }
+  const scale = remaining / oldOthersSum;
+  return prev.map((p, i) => (i === idx ? clamped : p * scale));
 }
 
 /// Phase 4 chunk Q: stacked-bar visualization of model-layer distribution

--- a/src/pages/Synapse.tsx
+++ b/src/pages/Synapse.tsx
@@ -17,8 +17,14 @@ import {
   Pencil,
 } from "lucide-react";
 import { useApp } from "../lib/store";
-import { api, listen } from "../lib/api";
-import type { SynapseMetric, SynapsePeer, SynapseRtt, SynapseWorker } from "../lib/types";
+import { api, listen, remoteSynapse } from "../lib/api";
+import type {
+  SynapseClusterLayout,
+  SynapseMetric,
+  SynapsePeer,
+  SynapseRtt,
+  SynapseWorker,
+} from "../lib/types";
 import { isTauri } from "../lib/util";
 import { AddPeerDialog } from "../components/AddPeerDialog";
 
@@ -94,6 +100,10 @@ export function Synapse() {
     hostname?: string;
     /** Present when editing an existing worker; absent when adding new. */
     initialToken?: string;
+    /** Phase 4 chunk N: pinned cert fingerprint (when adding from a
+     *  verified beacon) or pre-populated when editing a worker that
+     *  already has one stored. */
+    certFingerprint?: string;
   };
   const [dialogTarget, setDialogTarget] = useState<DialogTarget | null>(null);
 
@@ -104,6 +114,18 @@ export function Synapse() {
   const SPARK_LEN = 30;
   const [tokPerSecHistory, setTokPerSecHistory] = useState<number[]>([]);
   const [rttByEndpoint, setRttByEndpoint] = useState<Record<string, SynapseRtt>>({});
+  // Phase 4 chunk I: track which workers the heartbeat has evicted. A
+  // recovered event clears the entry. Stored as a Set so chip-render is
+  // an O(1) `.has()`.
+  const [evictedEndpoints, setEvictedEndpoints] = useState<Set<string>>(new Set());
+  // Phase 4 chunk O: live count of authenticated hosts connected to *this
+  // machine's* worker. Updates on every accept/disconnect via
+  // `synapse:sessions`. Only meaningful when worker mode is enabled.
+  const [activeSessions, setActiveSessions] = useState(0);
+  // Phase 4 chunk Q: layer-distribution snapshot from the most recent
+  // model load. We only display the most recent — older snapshots are
+  // stale once the model is reloaded with a different split.
+  const [clusterLayout, setClusterLayout] = useState<SynapseClusterLayout | null>(null);
 
   // Sync the worker toggle with backend reality on mount — the persisted store
   // can drift from the actual rpc-server child if the app crashed mid-run.
@@ -126,6 +148,9 @@ export function Synapse() {
       })
       .catch(() => {});
     api.getSynapseToken().then(setMyToken).catch(() => setMyToken(null));
+    // Phase 4 chunk O: cold-read the session count on mount in case the
+    // page (re-)opens with hosts already connected.
+    api.synapseActiveSessions().then(setActiveSessions).catch(() => {});
   }, [remote, setSynapseWorkerEnabled, setSynapseWorkerPort]);
 
   // Phase 3 chunk E: keep the backend's token map in sync so beacon HMACs can
@@ -162,6 +187,32 @@ export function Synapse() {
 
     listen<SynapseRtt>("synapse:rtt", (r) => {
       setRttByEndpoint((prev) => ({ ...prev, [r.endpoint]: r }));
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<{ endpoint: string }>("synapse:proxy-evicted", (e) => {
+      setEvictedEndpoints((prev) => {
+        if (prev.has(e.endpoint)) return prev;
+        const next = new Set(prev);
+        next.add(e.endpoint);
+        return next;
+      });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<{ endpoint: string }>("synapse:proxy-recovered", (e) => {
+      setEvictedEndpoints((prev) => {
+        if (!prev.has(e.endpoint)) return prev;
+        const next = new Set(prev);
+        next.delete(e.endpoint);
+        return next;
+      });
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<{ count: number }>("synapse:sessions", (e) => {
+      setActiveSessions(e.count);
+    }).then((un) => { if (cancelled) un(); else pending.push(un); });
+
+    listen<SynapseClusterLayout>("synapse:cluster-layout", (l) => {
+      setClusterLayout(l);
     }).then((un) => { if (cancelled) un(); else pending.push(un); });
 
     return () => {
@@ -300,9 +351,19 @@ export function Synapse() {
   // paste the worker's token before we save the entry. Adding without a
   // token is allowed (the chip flags it red) so users hitting cancel still
   // get a record of the discovery, but loads will fail until they edit.
+  //
+  // Phase 4 chunk N: capture the cert fingerprint from the (HMAC-signed)
+  // beacon at pair time, stored alongside the token. The host's TLS
+  // verifier then pins this exact fingerprint on every connect — a peer
+  // at the same IP can't impersonate the worker even if it learns the
+  // token.
   function openAddDialogForPeer(p: SynapsePeer) {
     if (synapse.workers.some((w) => w.endpoint === p.endpoint)) return;
-    setDialogTarget({ endpoint: p.endpoint, hostname: p.hostname });
+    setDialogTarget({
+      endpoint: p.endpoint,
+      hostname: p.hostname,
+      certFingerprint: p.certFingerprint,
+    });
   }
 
   // Click an existing chip → edit dialog, pre-populated with the current
@@ -318,11 +379,21 @@ export function Synapse() {
     const existing = synapse.workers.find((w) => w.endpoint === dialogTarget.endpoint);
     let next: SynapseWorker[];
     if (existing) {
+      // Edit-mode preserves whatever fingerprint was stored before; the
+      // dialog only edits the token. Re-pairing fully (re-running
+      // openAddDialogForPeer) is the way to refresh the fingerprint.
       next = synapse.workers.map((w) =>
         w.endpoint === dialogTarget.endpoint ? { ...w, token } : w,
       );
     } else {
-      next = [...synapse.workers, { endpoint: dialogTarget.endpoint, token }];
+      next = [
+        ...synapse.workers,
+        {
+          endpoint: dialogTarget.endpoint,
+          token,
+          certFingerprint: dialogTarget.certFingerprint,
+        },
+      ];
     }
     setSynapseWorkers(next);
     setWorkersText(workersToText(next));
@@ -349,6 +420,46 @@ export function Synapse() {
     const next = synapse.workers.map((w) => ({ ...w, weight: undefined }));
     setSynapseWorkers(next);
     setSynapseHostWeight(undefined);
+  }
+
+  // Phase 4 chunk L: pre-fill the layer split using each device's
+  // advertised VRAM. A real benchmark-tuned split would need to load the
+  // model under several configurations and measure tok/s — costly and
+  // tedious. VRAM-proportional is a strong heuristic for pipeline-parallel
+  // inference with similar bandwidth on each link, which is the common
+  // case on a home LAN.
+  //
+  // Host VRAM is read from `hardware`; peer VRAM from the latest beacon
+  // (cached in `peers`). Devices we can't read fall back to a 4 GB equal
+  // share so they aren't accidentally weighted to zero.
+  function suggestSplitFromVram() {
+    const hardware = useApp.getState().hardware;
+    let hostGb = 4;
+    if (hardware) {
+      const acc = hardware.accelerator;
+      if (acc.type === "appleSilicon") hostGb = acc.unifiedMemoryGb * 0.75;
+      else if (acc.type === "nvidia") hostGb = acc.vramGb;
+      else if (acc.type === "amd") hostGb = acc.vramGb;
+      else hostGb = Math.max(1, hardware.totalMemoryGb - 4);
+    }
+    // peers is keyed by mDNS instance id, but we want to look up by
+    // endpoint (host:port). Build a once-per-call index so each worker
+    // lookup stays O(1).
+    const peerByEndpoint: Record<string, SynapsePeer> = {};
+    for (const p of Object.values(peers)) peerByEndpoint[p.endpoint] = p;
+    const peerGbs = synapse.workers.map((w) => peerByEndpoint[w.endpoint]?.vramGb ?? 4);
+    // Normalize to the 0–1 range the SplitSlider binds to. We rescale so
+    // the largest device sits at 1.0; everything else is proportional.
+    // The backend re-normalizes again at --tensor-split build time, so
+    // only the *ratio* between values matters for inference — the
+    // absolute scale is purely cosmetic.
+    const max = Math.max(hostGb, ...peerGbs, 1);
+    const nextWorkers = synapse.workers.map((w, i) => ({
+      ...w,
+      weight: peerGbs[i] / max,
+    }));
+    setSynapseWorkers(nextWorkers);
+    setSynapseHostWeight(hostGb / max);
   }
 
   // Token actions — copy + rotate. Rotation is destructive; we confirm
@@ -395,16 +506,11 @@ export function Synapse() {
   );
 
   if (remote) {
-    // Phone/PWA — Synapse is desktop-only since it spawns child processes.
-    return (
-      <div className="flex flex-col h-full items-center justify-center text-center px-6">
-        <Network size={28} className="text-[var(--color-text-muted)] mb-3" />
-        <p className="text-sm text-[var(--color-text-muted)] max-w-sm">
-          Synapse runs on the desktop host — open LocalMind on the paired Mac/PC to
-          manage workers and peers.
-        </p>
-      </div>
-    );
+    // Phone/PWA — Phase 4 chunk P: read-only Synapse viewer. Fetches the
+    // desktop's worker status and discovered peers via the LAN API. We
+    // can't drive worker mode or edit tokens from here (desktop-only),
+    // but the diagnostic surface is identical.
+    return <RemoteSynapseView />;
   }
 
   return (
@@ -434,7 +540,22 @@ export function Synapse() {
             <div className="flex-1">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-sm font-medium">Run as a Synapse worker</div>
+                  <div className="text-sm font-medium flex items-center gap-2">
+                    Run as a Synapse worker
+                    {/* Phase 4 chunk O: live "N hosts connected" pill.
+                        Only shown when the worker is on AND at least one
+                        host is actually paired-and-active — a 0-count
+                        running worker is the steady-state idle case and
+                        the badge would just be visual noise. */}
+                    {synapse.workerEnabled && activeSessions > 0 && (
+                      <span
+                        title="Authenticated hosts currently connected"
+                        className="text-[10px] uppercase tracking-wider text-[var(--color-success)] bg-[var(--color-success)]/10 border border-[var(--color-success)]/40 rounded-full px-2 py-0.5"
+                      >
+                        {activeSessions} host{activeSessions === 1 ? "" : "s"}
+                      </span>
+                    )}
+                  </div>
                   <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
                     Spawns <code>rpc-server</code> and announces this machine on the LAN
                     via mDNS so other LocalMind hosts can find it automatically.
@@ -589,6 +710,17 @@ export function Synapse() {
                       <div className="text-xs text-[var(--color-text-muted)] font-mono truncate">
                         {p.endpoint}
                       </div>
+                      {/* Phase 4 chunk J: hardware blurb. We show it when
+                          available because users picking between two peers
+                          on the same LAN almost always want to know which
+                          has more VRAM. Hidden gracefully on pre-Phase-4
+                          workers where the fields are undefined. */}
+                      {(p.acceleratorName || p.vramGb) && (
+                        <div className="text-[11px] text-[var(--color-text-subtle)] truncate">
+                          {p.acceleratorName ?? "unknown"}
+                          {p.vramGb ? ` · ${p.vramGb.toFixed(1)} GB` : ""}
+                        </div>
+                      )}
                     </div>
                     <button
                       onClick={() => openAddDialogForPeer(p)}
@@ -643,6 +775,7 @@ export function Synapse() {
               {synapse.workers.map((w) => {
                 const missingToken = !w.token;
                 const rtt = rttByEndpoint[w.endpoint];
+                const evicted = evictedEndpoints.has(w.endpoint);
                 // RTT colour bands match common networking expectations:
                 //   <50 ms green (LAN healthy), 50–200 ms amber (Wi-Fi
                 //   contention), >200 ms red (VPN / WAN / dropping).
@@ -658,23 +791,32 @@ export function Synapse() {
                   <span
                     key={w.endpoint}
                     title={
-                      missingToken
-                        ? "No token — model load will fail. Click ✎ to add it."
-                        : "Click ✎ to update the token"
+                      evicted
+                        ? "Worker unreachable — heartbeat failed. Will auto-recover when the worker comes back."
+                        : missingToken
+                          ? "No token — model load will fail. Click ✎ to add it."
+                          : "Click ✎ to update the token"
                     }
                     className={`text-xs font-mono border rounded-full pl-2.5 pr-1 py-0.5 flex items-center gap-1 ${
-                      missingToken
-                        ? "bg-[var(--color-danger)]/10 border-[var(--color-danger)]/40"
-                        : "bg-[var(--color-panel-2)] border-[var(--color-border)]"
+                      evicted
+                        ? "bg-[var(--color-panel-2)] border-[var(--color-border)] opacity-60"
+                        : missingToken
+                          ? "bg-[var(--color-danger)]/10 border-[var(--color-danger)]/40"
+                          : "bg-[var(--color-panel-2)] border-[var(--color-border)]"
                     }`}
                   >
                     {w.endpoint}
-                    {rtt && (
+                    {evicted && (
+                      <span className="text-[var(--color-danger)] text-[10px] uppercase tracking-wider">
+                        offline
+                      </span>
+                    )}
+                    {!evicted && rtt && (
                       <span className={`text-[10px] ${rttClass}`}>
                         {rtt.ok ? `${rtt.rttMs}ms` : "drop"}
                       </span>
                     )}
-                    {missingToken && (
+                    {missingToken && !evicted && (
                       <span className="text-[var(--color-danger)] text-[10px] uppercase tracking-wider">
                         no token
                       </span>
@@ -696,6 +838,22 @@ export function Synapse() {
                   </span>
                 );
               })}
+            </div>
+          )}
+
+          {/* Phase 4 chunk Q: cluster layout. Stacked-bar visualization of
+              which device got how much model. Only renders after a model
+              load completes (we get the snapshot from llama-server's
+              "load_tensors: <DEVICE> model buffer size = …" lines). */}
+          {clusterLayout && clusterLayout.devices.length > 0 && (
+            <div className="mt-4">
+              <div className="flex items-center justify-between text-xs text-[var(--color-text-muted)] mb-1.5">
+                <span>Layer distribution (last load)</span>
+                <span className="text-[var(--color-text-subtle)]">
+                  {(clusterLayout.devices.reduce((a, b) => a + b.mb, 0) / 1024).toFixed(1)} GB total
+                </span>
+              </div>
+              <ClusterLayoutBar layout={clusterLayout} />
             </div>
           )}
 
@@ -745,17 +903,29 @@ export function Synapse() {
                       ({anyExplicit ? "custom" : "auto"})
                     </span>
                   </span>
-                  {anyExplicit && (
+                  <span className="flex items-center gap-3">
                     <button
                       onClick={(e) => {
                         e.preventDefault();
-                        clearAllWeights();
+                        suggestSplitFromVram();
                       }}
-                      className="text-[10px] uppercase tracking-wider text-[var(--color-text-subtle)] hover:text-[var(--color-text)]"
+                      className="text-[10px] uppercase tracking-wider text-[var(--color-accent)] hover:text-[var(--color-text)]"
+                      title="Pre-fill weights from each device's VRAM"
                     >
-                      reset
+                      suggest
                     </button>
-                  )}
+                    {anyExplicit && (
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          clearAllWeights();
+                        }}
+                        className="text-[10px] uppercase tracking-wider text-[var(--color-text-subtle)] hover:text-[var(--color-text)]"
+                      >
+                        reset
+                      </button>
+                    )}
+                  </span>
                 </summary>
                 <div className="mt-2 flex flex-col gap-2">
                   <SplitSlider
@@ -944,6 +1114,50 @@ function SplitSlider({
   );
 }
 
+/// Phase 4 chunk Q: stacked-bar visualization of model-layer distribution
+/// across host + RPC workers. We bucket by exact device label so a layout
+/// like `CUDA0 + RPC[127.0.0.1:54712] + CPU` shows three segments. Colour
+/// rotates through a small palette — the goal is "you can see the relative
+/// sizes" not "every device has its own brand colour."
+function ClusterLayoutBar({ layout }: { layout: SynapseClusterLayout }) {
+  const total = layout.devices.reduce((a, b) => a + b.mb, 0);
+  if (total === 0) return null;
+  // Tailwind-friendly palette. Order matches eye order in a typical
+  // pipeline split — host first, then workers.
+  const palette = [
+    "bg-[var(--color-accent)]",
+    "bg-[var(--color-success)]",
+    "bg-yellow-400",
+    "bg-purple-400",
+    "bg-pink-400",
+  ];
+  return (
+    <div>
+      <div className="flex h-3 rounded overflow-hidden border border-[var(--color-border)]">
+        {layout.devices.map((d, i) => (
+          <div
+            key={`${d.device}-${i}`}
+            title={`${d.device}: ${(d.mb / 1024).toFixed(2)} GB`}
+            className={palette[i % palette.length]}
+            style={{ width: `${(d.mb / total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] font-mono text-[var(--color-text-muted)]">
+        {layout.devices.map((d, i) => (
+          <span key={`${d.device}-${i}-legend`} className="flex items-center gap-1">
+            <span
+              aria-hidden
+              className={`inline-block w-2 h-2 rounded-sm ${palette[i % palette.length]}`}
+            />
+            {d.device} · {(d.mb / 1024).toFixed(2)} GB ({Math.round((d.mb / total) * 100)}%)
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 /// Tiny inline SVG sparkline. Avoids a charting dep — we only need a
 /// 30-point line for the tok/s feed. Auto-scales y to the visible range.
 function Sparkline({
@@ -992,5 +1206,146 @@ function Sparkline({
         className="text-[var(--color-accent)]"
       />
     </svg>
+  );
+}
+
+/// Phase 4 chunk P: read-only Synapse viewer for the phone PWA. Polls the
+/// desktop's `/api/synapse/*` endpoints every 5 s — no event subscription
+/// because the LAN server doesn't currently expose SSE/WebSocket for
+/// these and 5 s is plenty for the diagnostic use case.
+function RemoteSynapseView() {
+  const [workerStatus, setWorkerStatus] = useState<{
+    running: boolean;
+    port: number;
+    pid: number | null;
+  } | null>(null);
+  const [peers, setPeers] = useState<SynapsePeer[]>([]);
+  const [sessions, setSessions] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let stopped = false;
+    async function refresh() {
+      try {
+        const [s, p, sess] = await Promise.all([
+          remoteSynapse.status(),
+          remoteSynapse.peers(),
+          remoteSynapse.sessions(),
+        ]);
+        if (stopped) return;
+        setWorkerStatus(s);
+        setPeers(p);
+        setSessions(sess.count);
+        setError(null);
+      } catch (e: unknown) {
+        if (stopped) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+      }
+    }
+    refresh();
+    const id = setInterval(refresh, 5000);
+    return () => {
+      stopped = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="px-5 py-4 border-b border-[var(--color-border-soft)]">
+        <h1 className="font-semibold text-[17px] flex items-center gap-2">
+          <Network size={16} /> Synapse
+          <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-subtle)] bg-[var(--color-panel-2)] border border-[var(--color-border)] rounded-full px-2 py-0.5">
+            view-only
+          </span>
+        </h1>
+        <p className="text-[var(--color-text-muted)] text-sm">
+          Live status of the paired desktop's worker and discovered peers.
+          Editing happens on the desktop.
+        </p>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-5 py-5 max-w-3xl">
+        {error && (
+          <div className="mb-4 text-xs text-[var(--color-danger)] rounded-md border border-[var(--color-danger)]/40 bg-[var(--color-danger)]/10 px-3 py-2">
+            Couldn't reach desktop: {error}
+          </div>
+        )}
+
+        <div className="mb-6 rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <Server size={15} className="text-[var(--color-text-muted)]" />
+            <h2 className="font-semibold text-sm">Worker on desktop</h2>
+          </div>
+          {workerStatus ? (
+            <div className="grid grid-cols-2 gap-y-2 text-sm">
+              <div className="text-[var(--color-text-muted)]">Status</div>
+              <div className="text-right">
+                {workerStatus.running ? (
+                  <span className="text-[var(--color-success)]">running on :{workerStatus.port}</span>
+                ) : (
+                  <span className="text-[var(--color-text-subtle)]">idle</span>
+                )}
+              </div>
+              <div className="text-[var(--color-text-muted)]">PID</div>
+              <div className="text-right font-mono">{workerStatus.pid ?? "—"}</div>
+              <div className="text-[var(--color-text-muted)]">Active hosts</div>
+              <div className="text-right">{sessions}</div>
+            </div>
+          ) : (
+            <p className="text-sm text-[var(--color-text-muted)]">Loading…</p>
+          )}
+        </div>
+
+        <div className="mb-6 rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <Radio size={15} className="text-[var(--color-text-muted)]" />
+            <h2 className="font-semibold text-sm">Discovered on LAN ({peers.length})</h2>
+          </div>
+          {peers.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-subtle)]">No peers visible from the desktop.</p>
+          ) : (
+            <ul className="flex flex-col gap-1.5">
+              {peers.map((p) => (
+                <li
+                  key={p.id}
+                  className="flex items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-panel-2)] px-3 py-2"
+                >
+                  <div className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)]" />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate flex items-center gap-1.5">
+                      {p.hostname}
+                      {p.verified ? (
+                        <span title="HMAC verified" className="text-[var(--color-success)]">
+                          <Check size={12} />
+                        </span>
+                      ) : (
+                        <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-subtle)]">
+                          unverified
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-[var(--color-text-muted)] font-mono truncate">
+                      {p.endpoint}
+                    </div>
+                    {(p.acceleratorName || p.vramGb) && (
+                      <div className="text-[11px] text-[var(--color-text-subtle)] truncate">
+                        {p.acceleratorName ?? "unknown"}
+                        {p.vramGb ? ` · ${p.vramGb.toFixed(1)} GB` : ""}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <p className="text-[11px] text-[var(--color-text-subtle)] text-center">
+          Refreshes every 5 s · open the desktop app to manage peers
+        </p>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
 Closes #17                                                                                                                             
                                                                                                                                                
  ## Summary                                                                                                                                    
                                                            
  Implements all eleven items from the Synapse Phase 4 issue. Every                                                                             
  connection is now TLS-encrypted with cert pinning, the Marketplace shows
  real VRAM numbers, the layer-split editor is an explicit donut chart                                                                          
  where displayed percentages match what actually gets loaded, and the                                                                          
  host proxy handles worker death and recovery without requiring a model                                                                        
  reload.                                                                                                                                       
                                                                                                                                                
  ---                                                                                                                                           
                                                            
  ## What changed

  ### Security — TLS with cert pinning                                                                                              
   
  **New file: `src-tauri/src/synapse_tls.rs`**                                                                                                  
                                                            
  Workers generate a self-signed cert on first start (`synapse-cert.pem` +                                                                      
  `synapse-key.pem` in `data_dir`). A SHA-256 fingerprint of the leaf cert                                                                      
  rides inside the HMAC-signed beacon body — a man-in-the-middle cannot                                                                         
  swap the fingerprint without invalidating the HMAC.                                                                                           
                                                                                                                                                
  The host builds a `PinnedFingerprintVerifier` from the beacon fingerprint                                                                     
  and passes it to rustls as a custom `ServerCertVerifier`. The verifier                                                                        
  application byte is exchanged.                                                                                                                
                                                                                                                                                
  TOFU mode: when no fingerprint is available (pre-Phase-4 worker, or not                                                                       
  yet re-paired), the verifier short-circuits to accept-any. The token gate                                                                     
  at the application layer is the real defense in this mode — no regression                                                                     
  vs Phase 3.                                                                                                                                   
                                                                                                                                                
  Every probe, forward connection, and heartbeat now goes through `open_tls()`                                                                  
  in `host_proxy.rs`. The auth proxy wraps every accepted TCP connection in                                                                     
  `TlsAcceptor` before reading a single byte — port scanners and non-TLS                                                                        
  clients are dropped at the handshake.                                                                                                         
                                                                                                                                                
  ---                                                                                                                                           
                                                                                                                                                
  ### rustls CryptoProvider panic fix                                                                                                           
                                                            
  Added to the top of `run()` in `lib.rs`:
                                          
  ```rust                                                                                                                                       
  let _ = rustls::crypto::ring::default_provider().install_default();
```
                                                                                                                                                
  reqwest's rustls-tls feature pulls in hyper-rustls which enables                                                                              
  aws-lc-rs; our direct dep enables ring. With both features compiled                                                                           
  in, rustls refuses to auto-pick a provider and panics on first TLS use.                                                                       
  Pinning ring at app startup fixes the panic. Err on re-entry is                                                                               
  harmless (already installed).                                                                                                                 
                                                                                                                                                
  ---                                                                                                                                           
 ### Hardware telemetry in beacon               
                                                                                                                                                
  Workers now include vram_gb, accelerator_kind, and accelerator_name
  in BeaconPayload. Hardware is detected once at beacon spawn:                                                                                  
                                                                                                                                                
  - Apple Silicon: 75% of unified memory (matches macOS GPU pressure heuristic)                                                                 
  - NVIDIA/AMD: full VRAM                                                                                                                       
  - CPU-only: system RAM minus 4 GB OS reserve                                                                                                  
                                                            
  SynapsePeer gains the three hardware fields (optional; pre-Phase-4                                                                            
  peers leave them None). Marketplace replaces the hardcoded
  4 GB × peerCount estimate with the sum of real per-worker VRAMs from                                                                          
  the live peer cache. Falls back to 4 GB per peer when a worker hasn't                                                                         
  broadcast hardware yet.                                                                                                                       
                                                                                                                                                
  ---                                                                                                                                           
  ### Worker eviction & recovery                 
                                      
  The pinger in host_proxy.rs now counts consecutive failures. After 6
  misses (~30 s) it:                                                                                                                            
                                                                                                                                                
  1. Flips healthy: AtomicBool to false — the listener immediately                                                                              
  starts returning TCP RST to llama-server instead of forwarding                                                                                
  2. Emits synapse:proxy-evicted so the UI can mark the worker offline                                                                          
  3. Slows the ticker to 60 s cadence (vs 5 s healthy) to avoid hammering
  a sleeping machine                                                                                                                            
                                                            
  When a probe succeeds after eviction:                                                                                                         
                                                            
  1. healthy flips back to true                                                                                                                 
  2. synapse:proxy-recovered is emitted                     
  3. Ticker resets to 5 s cadence                                                                                                               
   
  No model reload required for recovery.                                                                                                        
                                                            
  ---                                                                                                                                           
 ### Session counter                          
                           
  ACTIVE_SESSIONS: AtomicU32 in auth_proxy.rs tracks live
  authenticated connections. Managed by SessionGuard, a RAII struct that                                                                        
  increments on construction and decrements on drop — including on panic,                                                                       
  so a misbehaving rpc-server can't strand the counter.                                                                                         
                                                                                                                                                
  The counter increments after the upstream dial succeeds, so                                                                                   
  half-open failures never show as ghost sessions.                                                                                              
                                                                                                                                                
  New Tauri command synapse_active_sessions reads the counter. Real-time
  synapse:sessions events are emitted on every increment and decrement.                                                                         
                                                                                                                                                
  ---
  ### Cluster layout visualization                                                                                                
                                                                                                                                                
  pipe_output in llama.rs now accumulates load_tensors: lines:
                                                                                                                                                
  load_tensors: CUDA0 model buffer size = 12345.67 MiB      
  load_tensors: RPC[127.0.0.1:54712] model buffer size = 9876.54 MiB                                                                            
                                                                                                                                                
  parse_buffer_line() extracts (device, MiB) pairs. When llama-server                                                                           
  signals load completion ("model loaded", "HTTP server listening",                                                                             
  etc.), all buffered pairs are emitted as a single synapse:cluster-layout                                                                      
  event. One render instead of N flickering ones; buffer clears on next                                                                         
  load.                                                                                                                                         
                                                                                                                                                
  ---                                                                                                                                           
  ### Prometheus metrics                  
                              
  New route /api/metrics on the LAN server returns hand-rolled Prometheus
  exposition text (no client lib dependency). Metrics exported:                                                                                 
                                                       
  Bearer-gated — same auth as the rest of /api.                                                                                                 
   
  ---                                                                                                                                           
  ### Phone PWA read-only views              
                                                                                                                                                
  Three new LAN endpoints on AppState:
                                                                                                                                                                                                                                     
   -  GET /api/synapse/status   - Returns { running, port, pid } 
   -  GET /api/synapse/peers    - Returns SynapsePeer[]
   -  GET /api/synapse/sessions  - Returns { count }         
   
  SynapseState is now cloned into AppState so the LAN server can                                                                                
  serve these without coupling to the Tauri IPC path.       
                                                                                                                                                
  remoteSynapse client added to api.ts for the phone PWA. Control                                                                               
  endpoints (start/stop, token edit, split change) remain desktop-only.                                                                         
                                                                                                                                                
  ---                                                       
  ### Marketplace fit filters                                                                                                           
                                                            
  New FitFilter type with four modes: all, fits-host, fits-cluster,
  needs-synapse. Rendered as pill buttons above search results.                                                                                 
                                                                                                                                                
  fits-cluster and needs-synapse only appear when at least one paired                                                                           
  worker exists — otherwise they're identical to fits-host and would                                                                            
  confuse users without a cluster.                                                                                                              
                                                                                                                                                
  ---
  ### Donut chart layer-split editor (Synapse.tsx)                                                                                                  
                                                                                                                                                
  Replaced the slider with SplitDonut — an SVG donut chart + numeric
  % inputs, one row per device.                                                                                                                 
                                                                                                                                                
  How it works:                                                                                                                                 
  - Raw weights from the store are normalized to percentages summing to                                                                         
  100% before display                                                                                                                           
  - Editing one input calls rebalance() which proportionally scales all
  other inputs so the total stays at 100%                                                                                                       
  - When all other inputs are at 0, the remainder is split evenly to avoid
  a dead-end where no redistribution is possible                                                                                                
  - Draft state (drafts: string[]) lets users erase and retype freely;                                                                          
  the store is only updated on blur or Enter                                                                                                    
  - useEffect re-syncs drafts from the store when an external action                                                                            
  (e.g. "Suggest" or "Reset") changes the weights                                                                                               
                                                                                                                                                
  The store still holds 0–1 raw weights; --tensor-split build path                                                                              
  in llama.rs is unchanged.                                                                                                                     
                                                                                                                                                
  Bug fixes bundled in:                                                                                                                         
  - commitWorkersText now merges parsed entries against the existing
  worker list by endpoint, preserving weight and certFingerprint                                                                                
  through textarea edits                                        
  - unwrap_or(1.0) → unwrap_or(0.5) for host and worker weights in                                                                              
  llama.rs — the old default silently outweighed a host the user had                                                                            
  dialed back, inverting the apparent split                                                                                                     
                                                                                                                                                                                                                                                                                                
  ---                                                                                                                                           
  ### Test plan                                                 
           
  - Start worker on a second machine; confirm (TLS, fp=…) in auth proxy log
  - Pair from host; paste token; confirm fingerprint is captured and stored                                                                     
  - Load a model with split configured; confirm --tensor-split arg in llama-server log                                                          
  - Edit a donut % input; verify other inputs rebalance and sum stays 100%                                                                      
  - Reload model after changing split; confirm new percentages reach llama.cpp                                                                  
  - Edit worker textarea; verify weight and fingerprint survive the re-parse                                                                    
  - Kill worker process; wait 30 s; confirm fast-reject behaviour; restart worker; confirm auto-recovery                                        
  - Open Marketplace with a paired worker; confirm real VRAM in budget; test all three filter pills                                             
  - curl -H "Authorization: Bearer <token>" http://<host>:3939/api/metrics → valid Prometheus text                                              
  - Phone browser: hit /api/synapse/peers → JSON array of peers                                                                                 
  - Worker UI session badge increments when host loads a model; decrements on stop                                                              
  - Confirm no rustls panic on fresh worker start 