### PR TITLE
feat(slots): multi-model concurrent serving (chat + embed + vision)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,10 @@ Shipped:
 - [x] Synapse v3 — token-gated auth proxy, HMAC-signed beacons, live tok/s + RTT, manual layer split, marketplace size hints
 - [x] Synapse v4 — TLS on the proxy channel, mid-inference reconnect, auto-tuned layer split, multi-host workers
 - [x] Service-worker offline shell for the PWA
+- [x] Multi-model concurrent serving (chat + embed + vision in one session)
 
 Next:
 - [ ] Tauri Mobile (iOS/Android) reaching parity with the PWA
-- [ ] Multi-model concurrent serving (chat + embed + vision in one session)
 - [ ] Speaker diarization for voice
 - [ ] Plugin system for custom tools
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2439,6 +2439,7 @@ dependencies = [
  "hostname",
  "local-ip-address",
  "mdns-sd",
+ "memchr",
  "rand 0.8.6",
  "rcgen",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,9 @@ rcgen = "0.13"
 tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
 rustls-pemfile = "2"
+# Plan 2 multi-model: cheap byte-search for routing /v1/chat/completions
+# bodies to the vision slot when image content parts are present.
+memchr = "2"
 
 [profile.release]
 lto = true

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -71,3 +71,9 @@ pub fn synapse_cert_path() -> PathBuf {
 pub fn synapse_key_path() -> PathBuf {
     data_dir().join("synapse-key.pem")
 }
+
+/// Plan 2 multi-model: persisted snapshot of which models are loaded
+/// in which slots. Read on boot to restore the active slot set.
+pub fn slots_state_path() -> PathBuf {
+    data_dir().join("slots.json")
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -310,6 +310,50 @@ fn synapse_active_sessions() -> u32 {
     auth_proxy::ACTIVE_SESSIONS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
+#[tauri::command]
+async fn start_slot(
+    app: AppHandle,
+    state: State<'_, Arc<AppStateHolder>>,
+    role: slots::Role,
+    model_id: String,
+    mmproj_id: Option<String>,
+) -> Result<LlamaStatus, String> {
+    let result = match role {
+        slots::Role::Chat => {
+            // Use the existing rich path — Synapse workers, host weight,
+            // mmproj as a chat-attached model — by constructing a minimal
+            // LlamaSettings. Callers that need flags (context, etc.)
+            // should still use the legacy start_llama command.
+            let settings = LlamaSettings {
+                model_id,
+                mmproj_id,
+                ..Default::default()
+            };
+            state.llama.start(&app, settings).await
+        }
+        slots::Role::Embed => state.llama.start_embedding(&app, model_id).await,
+        slots::Role::Vision => {
+            let mmproj = mmproj_id
+                .ok_or_else(|| anyhow::anyhow!("vision slot requires an mmproj_id"))?;
+            state.llama.start_vision(&app, model_id, mmproj).await
+        }
+    };
+    result.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn stop_slot(
+    state: State<'_, Arc<AppStateHolder>>,
+    role: slots::Role,
+) -> Result<(), String> {
+    let result = match role {
+        slots::Role::Chat => state.llama.stop().await,
+        slots::Role::Embed => state.llama.stop_embedding().await,
+        slots::Role::Vision => state.llama.stop_vision().await,
+    };
+    result.map_err(|e| e.to_string())
+}
+
 fn generate_pin() -> String {
     let raw = uuid::Uuid::new_v4().as_u128();
     format!("{:06}", (raw % 1_000_000) as u32)
@@ -420,6 +464,8 @@ pub fn run() {
             rotate_synapse_token,
             set_known_synapse_tokens,
             synapse_active_sessions,
+            start_slot,
+            stop_slot,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -334,7 +334,7 @@ async fn start_slot(
         slots::Role::Embed => state.llama.start_embedding(&app, model_id).await,
         slots::Role::Vision => {
             let mmproj = mmproj_id
-                .ok_or_else(|| anyhow::anyhow!("vision slot requires an mmproj_id"))?;
+                .ok_or_else(|| "vision slot requires an mmproj_id".to_string())?;
             state.llama.start_vision(&app, model_id, mmproj).await
         }
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod models;
 mod rag;
 mod sd;
 mod slots;
+mod slots_persist;
 mod server;
 mod synapse;
 mod synapse_proto;
@@ -418,6 +419,36 @@ pub fn run() {
                     Ok(url) => {
                         holder2.lan_url.set(url.clone());
                         let _ = handle.emit("lan:ready", url);
+
+                        // Plan 2 multi-model: restore any slots that
+                        // were active in the last session. Failures
+                        // here are logged, not fatal — a missing model
+                        // file (e.g. user deleted it between sessions)
+                        // shouldn't block boot.
+                        let llama_for_restore = holder2.llama.clone();
+                        let app_for_restore = handle.clone();
+                        tauri::async_runtime::spawn(async move {
+                            let snap = slots_persist::load();
+                            if let Some(id) = snap.chat_model_id {
+                                let settings = LlamaSettings {
+                                    model_id: id,
+                                    ..Default::default()
+                                };
+                                if let Err(e) = llama_for_restore.start(&app_for_restore, settings).await {
+                                    eprintln!("slots restore (chat): {e}");
+                                }
+                            }
+                            if let Some(id) = snap.embed_model_id {
+                                if let Err(e) = llama_for_restore.start_embedding(&app_for_restore, id).await {
+                                    eprintln!("slots restore (embed): {e}");
+                                }
+                            }
+                            if let (Some(id), Some(mmproj)) = (snap.vision_model_id, snap.vision_mmproj_id) {
+                                if let Err(e) = llama_for_restore.start_vision(&app_for_restore, id, mmproj).await {
+                                    eprintln!("slots restore (vision): {e}");
+                                }
+                            }
+                        });
                     }
                     Err(e) => {
                         eprintln!("LAN server failed: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,9 +7,9 @@ mod llama;
 mod models;
 mod rag;
 mod sd;
+mod server;
 mod slots;
 mod slots_persist;
-mod server;
 mod synapse;
 mod synapse_proto;
 mod synapse_tls;
@@ -334,8 +334,8 @@ async fn start_slot(
         }
         slots::Role::Embed => state.llama.start_embedding(&app, model_id).await,
         slots::Role::Vision => {
-            let mmproj = mmproj_id
-                .ok_or_else(|| "vision slot requires an mmproj_id".to_string())?;
+            let mmproj =
+                mmproj_id.ok_or_else(|| "vision slot requires an mmproj_id".to_string())?;
             state.llama.start_vision(&app, model_id, mmproj).await
         }
     };
@@ -343,10 +343,7 @@ async fn start_slot(
 }
 
 #[tauri::command]
-async fn stop_slot(
-    state: State<'_, Arc<AppStateHolder>>,
-    role: slots::Role,
-) -> Result<(), String> {
+async fn stop_slot(state: State<'_, Arc<AppStateHolder>>, role: slots::Role) -> Result<(), String> {
     let result = match role {
         slots::Role::Chat => state.llama.stop().await,
         slots::Role::Embed => state.llama.stop_embedding().await,
@@ -434,17 +431,27 @@ pub fn run() {
                                     model_id: id,
                                     ..Default::default()
                                 };
-                                if let Err(e) = llama_for_restore.start(&app_for_restore, settings).await {
+                                if let Err(e) =
+                                    llama_for_restore.start(&app_for_restore, settings).await
+                                {
                                     eprintln!("slots restore (chat): {e}");
                                 }
                             }
                             if let Some(id) = snap.embed_model_id {
-                                if let Err(e) = llama_for_restore.start_embedding(&app_for_restore, id).await {
+                                if let Err(e) = llama_for_restore
+                                    .start_embedding(&app_for_restore, id)
+                                    .await
+                                {
                                     eprintln!("slots restore (embed): {e}");
                                 }
                             }
-                            if let (Some(id), Some(mmproj)) = (snap.vision_model_id, snap.vision_mmproj_id) {
-                                if let Err(e) = llama_for_restore.start_vision(&app_for_restore, id, mmproj).await {
+                            if let (Some(id), Some(mmproj)) =
+                                (snap.vision_model_id, snap.vision_mmproj_id)
+                            {
+                                if let Err(e) = llama_for_restore
+                                    .start_vision(&app_for_restore, id, mmproj)
+                                    .await
+                                {
                                     eprintln!("slots restore (vision): {e}");
                                 }
                             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod llama;
 mod models;
 mod rag;
 mod sd;
+mod slots;
 mod server;
 mod synapse;
 mod synapse_proto;

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -70,86 +70,91 @@ pub struct LlamaStatus {
     pub embedding_model_id: Option<String>,
 }
 
-struct ServerHandle {
-    child: Option<Child>,
-    port: u16,
-    model_id: Option<String>,
-    mmproj_id: Option<String>,
-}
-
-impl ServerHandle {
-    fn new(default_port: u16) -> Self {
-        Self {
-            child: None,
-            port: default_port,
-            model_id: None,
-            mmproj_id: None,
-        }
-    }
-}
-
 pub struct LlamaState {
-    chat: Mutex<ServerHandle>,
-    embed: Mutex<ServerHandle>,
-    /// Phase 3: per-worker local proxies that authenticate with each remote
-    /// worker before bytes flow. Lifecycle is tied to the chat server: spun
-    /// up in `start`, torn down in `stop`. Owned here (rather than in
-    /// SynapseState) because that's where the lifecycle invariant lives.
+    /// One mutex over the whole table — all slot transitions go through
+    /// it. Slots are short-running operations (spawn child, wait_ready);
+    /// the mutex isn't held while llama-server is generating.
+    table: Mutex<crate::slots::SlotTable>,
+    /// Phase 3: per-worker local proxies that authenticate with each
+    /// remote worker before bytes flow. Lifecycle is tied to the **chat**
+    /// slot specifically — pipeline-sharded inference only makes sense
+    /// for the chat model. Embed and vision stay local-only.
     host_proxy: Arc<HostProxy>,
 }
 
 impl LlamaState {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
-            chat: Mutex::new(ServerHandle::new(8181)),
-            embed: Mutex::new(ServerHandle::new(8182)),
+            table: Mutex::new(crate::slots::SlotTable::new()),
             host_proxy: HostProxy::new(),
         })
     }
 
     pub async fn status(&self) -> LlamaStatus {
-        let chat = self.chat.lock().await;
-        let embed = self.embed.lock().await;
+        let table = self.table.lock().await;
+        let chat = table.get(crate::slots::Role::Chat);
+        let embed = table.get(crate::slots::Role::Embed);
+
+        // Legacy flat fields stay populated for one release so the
+        // existing frontend keeps working unmodified. Task 8 evolves
+        // the type to add the new `slots` array.
         LlamaStatus {
-            running: chat.child.is_some(),
-            port: chat.port,
-            model_id: chat.model_id.clone(),
-            mmproj_id: chat.mmproj_id.clone(),
-            pid: chat.child.as_ref().and_then(|c| c.id()),
-            embedding_running: embed.child.is_some(),
-            embedding_port: embed.port,
-            embedding_model_id: embed.model_id.clone(),
+            running: chat.is_some(),
+            port: chat
+                .map(|e| e.port)
+                .unwrap_or_else(|| crate::slots::Role::Chat.default_port()),
+            model_id: chat.map(|e| e.model_id.clone()),
+            mmproj_id: chat.and_then(|e| e.mmproj_id.clone()),
+            pid: chat.and_then(|e| e.child.id()),
+            embedding_running: embed.is_some(),
+            embedding_port: embed
+                .map(|e| e.port)
+                .unwrap_or_else(|| crate::slots::Role::Embed.default_port()),
+            embedding_model_id: embed.map(|e| e.model_id.clone()),
         }
     }
 
     pub async fn embedding_port(&self) -> u16 {
-        self.embed.lock().await.port
+        self.table
+            .lock()
+            .await
+            .get(crate::slots::Role::Embed)
+            .map(|e| e.port)
+            .unwrap_or_else(|| crate::slots::Role::Embed.default_port())
     }
 
     pub async fn embedding_running(&self) -> bool {
-        self.embed.lock().await.child.is_some()
+        self.table
+            .lock()
+            .await
+            .get(crate::slots::Role::Embed)
+            .is_some()
     }
 
     pub async fn stop(&self) -> Result<()> {
-        let mut chat = self.chat.lock().await;
-        if let Some(mut c) = chat.child.take() {
-            let _ = c.kill().await;
+        if let Some(mut entry) = self
+            .table
+            .lock()
+            .await
+            .remove(crate::slots::Role::Chat)
+        {
+            let _ = entry.child.kill().await;
         }
-        chat.model_id = None;
-        chat.mmproj_id = None;
-        // Phase 3: also free the local proxy ports + tasks. Done here (not in
-        // a separate command) so that "stop model" always means "stop
-        // everything model-related" — no leaked listeners.
+        // Synapse host proxies are tied to the chat slot's lifecycle —
+        // tear them down whenever chat goes away. Phase 3 invariant.
         self.host_proxy.stop_all().await;
         Ok(())
     }
 
     pub async fn stop_embedding(&self) -> Result<()> {
-        let mut embed = self.embed.lock().await;
-        if let Some(mut c) = embed.child.take() {
-            let _ = c.kill().await;
+        if let Some(mut entry) = self
+            .table
+            .lock()
+            .await
+            .remove(crate::slots::Role::Embed)
+        {
+            let _ = entry.child.kill().await;
         }
-        embed.model_id = None;
         Ok(())
     }
 
@@ -276,11 +281,20 @@ impl LlamaState {
         pipe_output(app, &mut child, "chat");
 
         {
-            let mut chat = self.chat.lock().await;
-            chat.child = Some(child);
-            chat.port = port;
-            chat.model_id = Some(settings.model_id.clone());
-            chat.mmproj_id = loaded_mmproj;
+            let mut table = self.table.lock().await;
+            // Insert atomically — if a previous chat slot existed (it shouldn't
+            // after the `self.stop().await?` at the top, but defensively):
+            if let Some(mut prev) = table.insert(
+                crate::slots::Role::Chat,
+                crate::slots::SlotEntry {
+                    child,
+                    port,
+                    model_id: settings.model_id.clone(),
+                    mmproj_id: loaded_mmproj.clone(),
+                },
+            ) {
+                let _ = prev.child.kill().await;
+            }
         }
 
         wait_ready(port).await?;
@@ -321,10 +335,18 @@ impl LlamaState {
         pipe_output(app, &mut child, "embed");
 
         {
-            let mut embed = self.embed.lock().await;
-            embed.child = Some(child);
-            embed.port = port;
-            embed.model_id = Some(model_id.clone());
+            let mut table = self.table.lock().await;
+            if let Some(mut prev) = table.insert(
+                crate::slots::Role::Embed,
+                crate::slots::SlotEntry {
+                    child,
+                    port,
+                    model_id: model_id.clone(),
+                    mmproj_id: None,
+                },
+            ) {
+                let _ = prev.child.kill().await;
+            }
         }
 
         wait_ready(port).await?;

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -475,6 +475,20 @@ impl LlamaState {
             .get(crate::slots::Role::Vision)
             .map(|e| (e.port, e.model_id.clone()))
     }
+
+    /// Pick the port a /v1/chat/completions request should be proxied to,
+    /// based on whether the body has any image_url content parts. Vision
+    /// slot wins for image-bearing requests when loaded; otherwise chat.
+    /// Returns `None` if neither slot can serve.
+    pub async fn route_chat_port(&self, has_image: bool) -> Option<u16> {
+        let table = self.table.lock().await;
+        if has_image {
+            if let Some(e) = table.get(crate::slots::Role::Vision) {
+                return Some(e.port);
+            }
+        }
+        table.get(crate::slots::Role::Chat).map(|e| e.port)
+    }
 }
 
 /// Pre-flight check: would loading `new_role` with the given file size

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -136,12 +136,7 @@ impl LlamaState {
     }
 
     pub async fn stop(&self) -> Result<()> {
-        if let Some(mut entry) = self
-            .table
-            .lock()
-            .await
-            .remove(crate::slots::Role::Chat)
-        {
+        if let Some(mut entry) = self.table.lock().await.remove(crate::slots::Role::Chat) {
             let _ = entry.child.kill().await;
         }
         // Synapse host proxies are tied to the chat slot's lifecycle —
@@ -152,12 +147,7 @@ impl LlamaState {
     }
 
     pub async fn stop_embedding(&self) -> Result<()> {
-        if let Some(mut entry) = self
-            .table
-            .lock()
-            .await
-            .remove(crate::slots::Role::Embed)
-        {
+        if let Some(mut entry) = self.table.lock().await.remove(crate::slots::Role::Embed) {
             let _ = entry.child.kill().await;
         }
         persist_snapshot(self).await;
@@ -391,12 +381,7 @@ impl LlamaState {
         mmproj_id: String,
     ) -> Result<LlamaStatus> {
         // Stop any existing vision slot first — we only support one at a time.
-        if let Some(mut prev) = self
-            .table
-            .lock()
-            .await
-            .remove(crate::slots::Role::Vision)
-        {
+        if let Some(mut prev) = self.table.lock().await.remove(crate::slots::Role::Vision) {
             let _ = prev.child.kill().await;
         }
 
@@ -459,12 +444,7 @@ impl LlamaState {
     }
 
     pub async fn stop_vision(&self) -> Result<()> {
-        if let Some(mut entry) = self
-            .table
-            .lock()
-            .await
-            .remove(crate::slots::Role::Vision)
-        {
+        if let Some(mut entry) = self.table.lock().await.remove(crate::slots::Role::Vision) {
             let _ = entry.child.kill().await;
         }
         persist_snapshot(self).await;

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -160,6 +160,12 @@ impl LlamaState {
 
     pub async fn start(&self, app: &AppHandle, settings: LlamaSettings) -> Result<LlamaStatus> {
         self.stop().await?;
+
+        let model_size = std::fs::metadata(models::model_path(&settings.model_id)?)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        preflight_vram(self, crate::slots::Role::Chat, model_size).await?;
+
         let port = settings.port.unwrap_or(8181);
         kill_orphan_on_port(port).await;
 
@@ -309,6 +315,12 @@ impl LlamaState {
 
     pub async fn start_embedding(&self, app: &AppHandle, model_id: String) -> Result<LlamaStatus> {
         self.stop_embedding().await?;
+
+        let model_size = std::fs::metadata(models::model_path(&model_id)?)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        preflight_vram(self, crate::slots::Role::Embed, model_size).await?;
+
         let port = 8182;
         kill_orphan_on_port(port).await;
 
@@ -379,6 +391,11 @@ impl LlamaState {
         {
             let _ = prev.child.kill().await;
         }
+
+        let model_size = std::fs::metadata(models::model_path(&model_id)?)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        preflight_vram(self, crate::slots::Role::Vision, model_size).await?;
 
         let preferred = crate::slots::Role::Vision.default_port();
         kill_orphan_on_port(preferred).await;
@@ -454,6 +471,48 @@ impl LlamaState {
             .get(crate::slots::Role::Vision)
             .map(|e| (e.port, e.model_id.clone()))
     }
+}
+
+/// Pre-flight check: would loading `new_role` with the given file size
+/// exceed available VRAM, given what's already loaded? Returns Ok if
+/// fine, or Err with a user-readable message. CPU-only hardware skips
+/// the check and returns Ok.
+async fn preflight_vram(
+    state: &LlamaState,
+    new_role: crate::slots::Role,
+    new_size_bytes: u64,
+) -> Result<()> {
+    let hw = hardware::detect();
+    let Some(avail) = crate::slots::available_gpu_memory_gb(&hw) else {
+        return Ok(());
+    };
+    let table = state.table.lock().await;
+    let mut existing: Vec<u64> = Vec::new();
+    for r in [
+        crate::slots::Role::Chat,
+        crate::slots::Role::Embed,
+        crate::slots::Role::Vision,
+    ] {
+        // Skip the role we're about to (re)load — we'll free its
+        // memory before spawning the new child.
+        if r == new_role {
+            continue;
+        }
+        if let Some(entry) = table.get(r) {
+            if let Ok(p) = models::model_path(&entry.model_id) {
+                if let Ok(meta) = std::fs::metadata(p) {
+                    existing.push(meta.len());
+                }
+            }
+        }
+    }
+    drop(table);
+    if !crate::slots::fits_with_existing(&existing, new_size_bytes, avail) {
+        return Err(anyhow!(
+            "loading this model would exceed available GPU memory ({avail:.1} GB). Unload another slot first."
+        ));
+    }
+    Ok(())
 }
 
 fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -358,6 +358,102 @@ impl LlamaState {
 
         Ok(self.status().await)
     }
+
+    /// Start a dedicated vision slot. Independent of the chat slot:
+    /// a user can have a 7B chat model + a 7B LLaVA loaded at the same
+    /// time, and image-bearing chat requests get routed to this slot.
+    /// Synapse pipelining is intentionally NOT applied — vision is
+    /// local-only.
+    pub async fn start_vision(
+        &self,
+        app: &AppHandle,
+        model_id: String,
+        mmproj_id: String,
+    ) -> Result<LlamaStatus> {
+        // Stop any existing vision slot first — we only support one at a time.
+        if let Some(mut prev) = self
+            .table
+            .lock()
+            .await
+            .remove(crate::slots::Role::Vision)
+        {
+            let _ = prev.child.kill().await;
+        }
+
+        let preferred = crate::slots::Role::Vision.default_port();
+        kill_orphan_on_port(preferred).await;
+        let pool = crate::slots::port_pool(crate::slots::Role::Vision);
+        let port = crate::slots::pick_port(preferred, &pool, crate::slots::port_is_free)
+            .ok_or_else(|| anyhow!("no free port in vision pool {pool:?}"))?;
+
+        let binary = binaries::ensure_llama_server(app).await?;
+        let model = models::model_path(&model_id)?;
+        let mmproj_path = models::model_path(&mmproj_id)?;
+        let hw = hardware::detect();
+        let threads = (hw.cpu_cores as u32).saturating_sub(1).max(1);
+        let n_gpu = hw.recommended_n_gpu_layers;
+
+        let mut cmd = Command::new(&binary);
+        cmd.arg("-m").arg(&model);
+        cmd.arg("--mmproj").arg(&mmproj_path);
+        cmd.arg("--host").arg("127.0.0.1");
+        cmd.arg("--port").arg(port.to_string());
+        cmd.arg("-t").arg(threads.to_string());
+        cmd.arg("-ngl").arg(n_gpu.to_string());
+        cmd.arg("--jinja");
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| anyhow!("failed to spawn vision llama-server: {e}"))?;
+        pipe_output(app, &mut child, "vision");
+
+        {
+            let mut table = self.table.lock().await;
+            table.insert(
+                crate::slots::Role::Vision,
+                crate::slots::SlotEntry {
+                    child,
+                    port,
+                    model_id: model_id.clone(),
+                    mmproj_id: Some(mmproj_id.clone()),
+                },
+            );
+        }
+
+        wait_ready(port).await?;
+
+        let _ = app.emit(
+            "llama:ready",
+            serde_json::json!({ "port": port, "modelId": model_id, "stream": "vision" }),
+        );
+
+        Ok(self.status().await)
+    }
+
+    pub async fn stop_vision(&self) -> Result<()> {
+        if let Some(mut entry) = self
+            .table
+            .lock()
+            .await
+            .remove(crate::slots::Role::Vision)
+        {
+            let _ = entry.child.kill().await;
+        }
+        Ok(())
+    }
+
+    /// Read-only snapshot of the vision slot's port + model. None when
+    /// vision isn't loaded. Used by `server.rs::proxy_v1` to route
+    /// image-bearing requests.
+    pub async fn vision_slot(&self) -> Option<(u16, String)> {
+        self.table
+            .lock()
+            .await
+            .get(crate::slots::Role::Vision)
+            .map(|e| (e.port, e.model_id.clone()))
+    }
 }
 
 fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -60,6 +60,9 @@ pub struct LlamaSettings {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LlamaStatus {
+    /// Legacy flat fields — derived from `slots`. Kept populated for
+    /// one release so the frontend can migrate incrementally. New code
+    /// should read `slots` directly.
     pub running: bool,
     pub port: u16,
     pub model_id: Option<String>,
@@ -68,6 +71,9 @@ pub struct LlamaStatus {
     pub embedding_running: bool,
     pub embedding_port: u16,
     pub embedding_model_id: Option<String>,
+    /// Canonical: one entry per role (always exactly 3, in the order
+    /// chat / embed / vision). `running == false` for unloaded roles.
+    pub slots: Vec<crate::slots::SlotStatus>,
 }
 
 pub struct LlamaState {
@@ -94,10 +100,7 @@ impl LlamaState {
         let table = self.table.lock().await;
         let chat = table.get(crate::slots::Role::Chat);
         let embed = table.get(crate::slots::Role::Embed);
-
-        // Legacy flat fields stay populated for one release so the
-        // existing frontend keeps working unmodified. Task 8 evolves
-        // the type to add the new `slots` array.
+        let slots = table.statuses();
         LlamaStatus {
             running: chat.is_some(),
             port: chat
@@ -111,6 +114,7 @@ impl LlamaState {
                 .map(|e| e.port)
                 .unwrap_or_else(|| crate::slots::Role::Embed.default_port()),
             embedding_model_id: embed.map(|e| e.model_id.clone()),
+            slots,
         }
     }
 

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -147,6 +147,7 @@ impl LlamaState {
         // Synapse host proxies are tied to the chat slot's lifecycle —
         // tear them down whenever chat goes away. Phase 3 invariant.
         self.host_proxy.stop_all().await;
+        persist_snapshot(self).await;
         Ok(())
     }
 
@@ -159,6 +160,7 @@ impl LlamaState {
         {
             let _ = entry.child.kill().await;
         }
+        persist_snapshot(self).await;
         Ok(())
     }
 
@@ -314,6 +316,7 @@ impl LlamaState {
             serde_json::json!({ "port": port, "modelId": settings.model_id, "stream": "chat" }),
         );
 
+        persist_snapshot(self).await;
         Ok(self.status().await)
     }
 
@@ -372,6 +375,7 @@ impl LlamaState {
             serde_json::json!({ "port": port, "modelId": model_id, "stream": "embed" }),
         );
 
+        persist_snapshot(self).await;
         Ok(self.status().await)
     }
 
@@ -450,6 +454,7 @@ impl LlamaState {
             serde_json::json!({ "port": port, "modelId": model_id, "stream": "vision" }),
         );
 
+        persist_snapshot(self).await;
         Ok(self.status().await)
     }
 
@@ -462,6 +467,7 @@ impl LlamaState {
         {
             let _ = entry.child.kill().await;
         }
+        persist_snapshot(self).await;
         Ok(())
     }
 
@@ -531,6 +537,17 @@ async fn preflight_vram(
         ));
     }
     Ok(())
+}
+
+/// Snapshot the active slot set to disk so a relaunch can re-hydrate.
+/// Failures are logged but never returned — persistence is a
+/// nice-to-have, not a correctness requirement.
+async fn persist_snapshot(state: &LlamaState) {
+    let status = state.status().await;
+    let snap = crate::slots_persist::snapshot_from_status(&status.slots);
+    if let Err(e) = crate::slots_persist::save(&snap) {
+        eprintln!("slots persist failed: {e}");
+    }
 }
 
 fn pipe_output(app: &AppHandle, child: &mut Child, tag: &str) {

--- a/src-tauri/src/llama.rs
+++ b/src-tauri/src/llama.rs
@@ -472,8 +472,10 @@ impl LlamaState {
     }
 
     /// Read-only snapshot of the vision slot's port + model. None when
-    /// vision isn't loaded. Used by `server.rs::proxy_v1` to route
-    /// image-bearing requests.
+    /// vision isn't loaded. Currently unused — `route_chat_port` does
+    /// the routing inline — but kept for callers that want explicit
+    /// per-slot lookups (e.g. a future Synapse panel UI).
+    #[allow(dead_code)]
     pub async fn vision_slot(&self) -> Option<(u16, String)> {
         self.table
             .lock()

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -17,6 +17,19 @@ use std::sync::{Arc, Mutex};
 use tower_http::{cors::CorsLayer, services::ServeDir};
 use uuid::Uuid;
 
+/// Cheap scan of a JSON chat body for any `image_url` content part.
+/// We avoid full deserialization: the body can be large and we need
+/// to forward it through verbatim — re-serializing would change byte
+/// layout and break tools that hash request bodies.
+fn body_has_image(body: &[u8]) -> bool {
+    // String-search for the literal field name. Safe: chat-completions
+    // bodies are JSON, and `"image_url"` only appears as a key in the
+    // OpenAI multimodal content-part schema. False positives would
+    // require user prompts containing the exact 11-character literal,
+    // which routes them to vision (capable model) — still correct.
+    memchr::memmem::find(body, b"\"image_url\"").is_some()
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub llama: Arc<LlamaState>,
@@ -206,19 +219,54 @@ async fn proxy_dev_frontend(State(s): State<AppState>, req: Request<Body>) -> Re
 }
 
 async fn proxy_v1(State(s): State<AppState>, req: Request<Body>) -> Response {
-    let st = s.llama.status().await;
-    if !st.running {
-        return (StatusCode::SERVICE_UNAVAILABLE, "no model loaded on host").into_response();
-    }
-    let port = st.port;
+    // Materialize the body so we can inspect it and still forward it.
+    // 64 MB cap matches the existing forward() limit.
     let path = req.uri().path().to_string();
     let qs = req
         .uri()
         .query()
         .map(|q| format!("?{q}"))
         .unwrap_or_default();
+    let method = req.method().clone();
+    let headers = req.headers().clone();
+    let body_bytes = match axum::body::to_bytes(req.into_body(), 64 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(e) => return (StatusCode::BAD_REQUEST, format!("body error: {e}")).into_response(),
+    };
+
+    // Route only /v1/chat/completions; other /v1/* (e.g. /v1/models) stays on chat.
+    let port = if path == "/v1/chat/completions" {
+        let has_image = body_has_image(&body_bytes);
+        match s.llama.route_chat_port(has_image).await {
+            Some(p) => p,
+            None => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "no chat or vision model loaded",
+                )
+                    .into_response()
+            }
+        }
+    } else {
+        let st = s.llama.status().await;
+        if !st.running {
+            return (StatusCode::SERVICE_UNAVAILABLE, "no model loaded on host").into_response();
+        }
+        st.port
+    };
+
     let url = format!("http://127.0.0.1:{}{}{}", port, path, qs);
-    forward(&s.http, &url, req).await
+
+    // Re-construct a Request<Body> for forward(), since we already
+    // consumed the original body.
+    let mut new_req = Request::builder()
+        .method(method)
+        .uri(format!("{}{}", path, qs))
+        .body(Body::from(body_bytes.clone()))
+        .unwrap();
+    *new_req.headers_mut() = headers;
+
+    forward(&s.http, &url, new_req).await
 }
 
 async fn forward(client: &reqwest::Client, url: &str, req: Request<Body>) -> Response {

--- a/src-tauri/src/slots.rs
+++ b/src-tauri/src/slots.rs
@@ -130,6 +130,43 @@ pub fn port_pool(role: Role) -> Vec<u16> {
     }
 }
 
+use crate::hardware::{Accelerator, HardwareInfo};
+
+/// VRAM (or unified memory) available for inference, in GB. Returns
+/// None for CPU-only systems (no hard upper bound — caller falls back
+/// to RAM check). Apple Silicon reserves 30% for the OS and Metal
+/// surfaces; on dedicated GPUs we use the full reported VRAM since the
+/// OS lives in system RAM.
+pub fn available_gpu_memory_gb(hw: &HardwareInfo) -> Option<f64> {
+    match &hw.accelerator {
+        Accelerator::AppleSilicon { unified_memory_gb, .. } => Some(unified_memory_gb * 0.7),
+        Accelerator::Nvidia { vram_gb, .. } => Some(*vram_gb),
+        Accelerator::Amd { vram_gb, .. } => Some(*vram_gb),
+        Accelerator::IntelArc { .. } | Accelerator::Cpu => None,
+    }
+}
+
+/// Rough per-slot VRAM estimate. A fully-offloaded GGUF takes
+/// approximately its file size in VRAM at load time, plus ~0.5 GB
+/// for KV cache + activation overhead at the default 4k context.
+/// Conservative — we'd rather refuse a load that would have just
+/// barely fit than OOM mid-inference.
+pub fn estimate_slot_vram_gb(file_size_bytes: u64) -> f64 {
+    (file_size_bytes as f64 / 1024.0 / 1024.0 / 1024.0) + 0.5
+}
+
+/// Would loading a new model with `new_size_bytes` push total estimated
+/// VRAM use past `available_gb`?
+pub fn fits_with_existing(
+    existing_sizes: &[u64],
+    new_size_bytes: u64,
+    available_gb: f64,
+) -> bool {
+    let used: f64 = existing_sizes.iter().map(|&b| estimate_slot_vram_gb(b)).sum();
+    let needed = estimate_slot_vram_gb(new_size_bytes);
+    used + needed <= available_gb
+}
+
 /// One slot's externally-visible state. Returned to the frontend as
 /// part of `LlamaStatus.slots`.
 #[derive(Debug, Clone, Serialize)]
@@ -261,5 +298,62 @@ mod tests {
         let probe = |_: u16| false;
         let port = pick_port(8181, &[8181, 8182, 8183], probe);
         assert_eq!(port, None);
+    }
+
+    fn hw(accel: Accelerator) -> HardwareInfo {
+        HardwareInfo {
+            os: "macos".into(),
+            arch: "aarch64".into(),
+            cpu_name: "test".into(),
+            cpu_cores: 8,
+            total_memory_gb: 16.0,
+            accelerator: accel,
+            recommended_backend: "metal".into(),
+            recommended_n_gpu_layers: -1,
+        }
+    }
+
+    #[test]
+    fn available_gpu_memory_apple_silicon_reserves_30pct() {
+        let info = hw(Accelerator::AppleSilicon { chip: "M1 Pro".into(), unified_memory_gb: 16.0 });
+        let avail = available_gpu_memory_gb(&info).unwrap();
+        // 70% of 16 = 11.2; allow small float wiggle.
+        assert!((avail - 11.2).abs() < 0.01);
+    }
+
+    #[test]
+    fn available_gpu_memory_nvidia_uses_full_vram() {
+        let info = hw(Accelerator::Nvidia { name: "4090".into(), vram_gb: 24.0, cuda_version: None });
+        assert_eq!(available_gpu_memory_gb(&info), Some(24.0));
+    }
+
+    #[test]
+    fn available_gpu_memory_cpu_returns_none() {
+        let info = hw(Accelerator::Cpu);
+        assert_eq!(available_gpu_memory_gb(&info), None);
+    }
+
+    #[test]
+    fn slot_vram_estimate_adds_kv_overhead() {
+        // 4 GB file → ~4.5 GB estimate (file + 0.5 GB for KV cache).
+        let bytes = 4 * 1024 * 1024 * 1024_u64;
+        let est = estimate_slot_vram_gb(bytes);
+        assert!((est - 4.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn fits_with_existing_passes_when_under_budget() {
+        // 4 GB existing + 2 GB new = ~7 GB used (incl. overhead) within 16 GB.
+        let existing = vec![4 * 1024 * 1024 * 1024_u64];
+        let new_model = 2 * 1024 * 1024 * 1024_u64;
+        assert!(fits_with_existing(&existing, new_model, 16.0));
+    }
+
+    #[test]
+    fn fits_with_existing_fails_when_over_budget() {
+        // 10 GB + 8 GB ≈ 19 GB > 16 GB available.
+        let existing = vec![10 * 1024 * 1024 * 1024_u64];
+        let new_model = 8 * 1024 * 1024 * 1024_u64;
+        assert!(!fits_with_existing(&existing, new_model, 16.0));
     }
 }

--- a/src-tauri/src/slots.rs
+++ b/src-tauri/src/slots.rs
@@ -143,7 +143,9 @@ use crate::hardware::{Accelerator, HardwareInfo};
 /// OS lives in system RAM.
 pub fn available_gpu_memory_gb(hw: &HardwareInfo) -> Option<f64> {
     match &hw.accelerator {
-        Accelerator::AppleSilicon { unified_memory_gb, .. } => Some(unified_memory_gb * 0.7),
+        Accelerator::AppleSilicon {
+            unified_memory_gb, ..
+        } => Some(unified_memory_gb * 0.7),
         Accelerator::Nvidia { vram_gb, .. } => Some(*vram_gb),
         Accelerator::Amd { vram_gb, .. } => Some(*vram_gb),
         Accelerator::IntelArc { .. } | Accelerator::Cpu => None,
@@ -161,12 +163,11 @@ pub fn estimate_slot_vram_gb(file_size_bytes: u64) -> f64 {
 
 /// Would loading a new model with `new_size_bytes` push total estimated
 /// VRAM use past `available_gb`?
-pub fn fits_with_existing(
-    existing_sizes: &[u64],
-    new_size_bytes: u64,
-    available_gb: f64,
-) -> bool {
-    let used: f64 = existing_sizes.iter().map(|&b| estimate_slot_vram_gb(b)).sum();
+pub fn fits_with_existing(existing_sizes: &[u64], new_size_bytes: u64, available_gb: f64) -> bool {
+    let used: f64 = existing_sizes
+        .iter()
+        .map(|&b| estimate_slot_vram_gb(b))
+        .sum();
     let needed = estimate_slot_vram_gb(new_size_bytes);
     used + needed <= available_gb
 }
@@ -217,11 +218,18 @@ mod tests {
         // we can hold and drop without it actually doing anything.
         #[cfg(target_family = "unix")]
         {
-            tokio::process::Command::new("true").stdout(Stdio::null()).spawn().unwrap()
+            tokio::process::Command::new("true")
+                .stdout(Stdio::null())
+                .spawn()
+                .unwrap()
         }
         #[cfg(target_os = "windows")]
         {
-            tokio::process::Command::new("cmd").args(["/c", "exit"]).stdout(Stdio::null()).spawn().unwrap()
+            tokio::process::Command::new("cmd")
+                .args(["/c", "exit"])
+                .stdout(Stdio::null())
+                .spawn()
+                .unwrap()
         }
     }
 
@@ -319,7 +327,10 @@ mod tests {
 
     #[test]
     fn available_gpu_memory_apple_silicon_reserves_30pct() {
-        let info = hw(Accelerator::AppleSilicon { chip: "M1 Pro".into(), unified_memory_gb: 16.0 });
+        let info = hw(Accelerator::AppleSilicon {
+            chip: "M1 Pro".into(),
+            unified_memory_gb: 16.0,
+        });
         let avail = available_gpu_memory_gb(&info).unwrap();
         // 70% of 16 = 11.2; allow small float wiggle.
         assert!((avail - 11.2).abs() < 0.01);
@@ -327,7 +338,11 @@ mod tests {
 
     #[test]
     fn available_gpu_memory_nvidia_uses_full_vram() {
-        let info = hw(Accelerator::Nvidia { name: "4090".into(), vram_gb: 24.0, cuda_version: None });
+        let info = hw(Accelerator::Nvidia {
+            name: "4090".into(),
+            vram_gb: 24.0,
+            cuda_version: None,
+        });
         assert_eq!(available_gpu_memory_gb(&info), Some(24.0));
     }
 

--- a/src-tauri/src/slots.rs
+++ b/src-tauri/src/slots.rs
@@ -36,6 +36,73 @@ impl Role {
     }
 }
 
+/// Internal handle for a running llama-server child. Held inside the
+/// SlotTable; not exposed across the module boundary because callers
+/// have no business poking at the `Child` directly.
+pub struct SlotEntry {
+    pub child: tokio::process::Child,
+    pub port: u16,
+    pub model_id: String,
+    pub mmproj_id: Option<String>,
+}
+
+/// Map keyed by Role. We don't use a HashMap — there are exactly three
+/// roles and a fixed-size array is faster, simpler, and self-documents.
+#[derive(Default)]
+pub struct SlotTable {
+    chat: Option<SlotEntry>,
+    embed: Option<SlotEntry>,
+    vision: Option<SlotEntry>,
+}
+
+impl SlotTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self, role: Role) -> Option<&SlotEntry> {
+        match role {
+            Role::Chat => self.chat.as_ref(),
+            Role::Embed => self.embed.as_ref(),
+            Role::Vision => self.vision.as_ref(),
+        }
+    }
+
+    pub fn insert(&mut self, role: Role, entry: SlotEntry) -> Option<SlotEntry> {
+        let slot = match role {
+            Role::Chat => &mut self.chat,
+            Role::Embed => &mut self.embed,
+            Role::Vision => &mut self.vision,
+        };
+        slot.replace(entry)
+    }
+
+    pub fn remove(&mut self, role: Role) -> Option<SlotEntry> {
+        match role {
+            Role::Chat => self.chat.take(),
+            Role::Embed => self.embed.take(),
+            Role::Vision => self.vision.take(),
+        }
+    }
+
+    pub fn statuses(&self) -> Vec<SlotStatus> {
+        [Role::Chat, Role::Embed, Role::Vision]
+            .iter()
+            .map(|&r| {
+                let entry = self.get(r);
+                SlotStatus {
+                    role: r,
+                    running: entry.is_some(),
+                    port: entry.map(|e| e.port).unwrap_or_else(|| r.default_port()),
+                    model_id: entry.map(|e| e.model_id.clone()),
+                    mmproj_id: entry.and_then(|e| e.mmproj_id.clone()),
+                    pid: entry.and_then(|e| e.child.id()),
+                }
+            })
+            .collect()
+    }
+}
+
 /// One slot's externally-visible state. Returned to the frontend as
 /// part of `LlamaStatus.slots`.
 #[derive(Debug, Clone, Serialize)]
@@ -73,5 +140,78 @@ mod tests {
         assert_eq!(Role::Chat.as_str(), "chat");
         assert_eq!(Role::Embed.as_str(), "embed");
         assert_eq!(Role::Vision.as_str(), "vision");
+    }
+
+    use std::process::Stdio;
+
+    fn dummy_child() -> tokio::process::Child {
+        // Spawn `true` (Unix) or `cmd /c` (Windows) — we just need a Child
+        // we can hold and drop without it actually doing anything.
+        #[cfg(target_family = "unix")]
+        {
+            tokio::process::Command::new("true").stdout(Stdio::null()).spawn().unwrap()
+        }
+        #[cfg(target_os = "windows")]
+        {
+            tokio::process::Command::new("cmd").args(["/c", "exit"]).stdout(Stdio::null()).spawn().unwrap()
+        }
+    }
+
+    fn dummy_entry(port: u16, model_id: &str) -> SlotEntry {
+        SlotEntry {
+            child: dummy_child(),
+            port,
+            model_id: model_id.to_string(),
+            mmproj_id: None,
+        }
+    }
+
+    #[test]
+    fn empty_table_has_no_running_slots() {
+        let t = SlotTable::new();
+        let statuses = t.statuses();
+        assert_eq!(statuses.len(), 3);
+        assert!(statuses.iter().all(|s| !s.running));
+    }
+
+    // The remaining tests need a tokio runtime because they spawn
+    // child processes via `tokio::process::Command` (so SlotEntry can
+    // hold a real `tokio::process::Child`).
+
+    #[tokio::test]
+    async fn insert_then_get_returns_entry() {
+        let mut t = SlotTable::new();
+        t.insert(Role::Chat, dummy_entry(8181, "chat-7b"));
+        assert!(t.get(Role::Chat).is_some());
+        assert!(t.get(Role::Embed).is_none());
+    }
+
+    #[tokio::test]
+    async fn insert_returns_previous_entry() {
+        let mut t = SlotTable::new();
+        t.insert(Role::Chat, dummy_entry(8181, "chat-7b"));
+        let prev = t.insert(Role::Chat, dummy_entry(8181, "chat-13b"));
+        assert!(prev.is_some());
+        assert_eq!(prev.unwrap().model_id, "chat-7b");
+        assert_eq!(t.get(Role::Chat).unwrap().model_id, "chat-13b");
+    }
+
+    #[tokio::test]
+    async fn remove_takes_entry_out() {
+        let mut t = SlotTable::new();
+        t.insert(Role::Vision, dummy_entry(8183, "llava"));
+        let taken = t.remove(Role::Vision);
+        assert!(taken.is_some());
+        assert!(t.get(Role::Vision).is_none());
+    }
+
+    #[tokio::test]
+    async fn statuses_reflects_loaded_slots() {
+        let mut t = SlotTable::new();
+        t.insert(Role::Embed, dummy_entry(8182, "nomic-embed"));
+        let statuses = t.statuses();
+        let embed = statuses.iter().find(|s| s.role == Role::Embed).unwrap();
+        assert!(embed.running);
+        assert_eq!(embed.model_id.as_deref(), Some("nomic-embed"));
     }
 }

--- a/src-tauri/src/slots.rs
+++ b/src-tauri/src/slots.rs
@@ -27,6 +27,10 @@ impl Role {
         }
     }
 
+    /// Stable string form for logs and Tauri-event payloads. Currently
+    /// only exercised in tests; intentionally part of the public API
+    /// because subsequent plans wire it into Tauri events.
+    #[allow(dead_code)]
     pub fn as_str(self) -> &'static str {
         match self {
             Role::Chat => "chat",

--- a/src-tauri/src/slots.rs
+++ b/src-tauri/src/slots.rs
@@ -103,6 +103,33 @@ impl SlotTable {
     }
 }
 
+/// Pick a free port. Tries `preferred` first, then walks `pool` in order.
+/// `is_free(port)` returns true when the port is bindable.
+///
+/// Pure over the probe so we can unit-test without binding sockets;
+/// the production caller passes a probe that does a real `TcpListener::bind`.
+pub fn pick_port<F: Fn(u16) -> bool>(preferred: u16, pool: &[u16], is_free: F) -> Option<u16> {
+    if is_free(preferred) {
+        return Some(preferred);
+    }
+    pool.iter().copied().find(|&p| p != preferred && is_free(p))
+}
+
+/// Production probe: try to bind, drop the listener immediately.
+pub fn port_is_free(port: u16) -> bool {
+    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+/// Default pool per role. We pick small, contiguous ranges so a curious
+/// user `lsof`-ing the desktop sees obvious neighbours.
+pub fn port_pool(role: Role) -> Vec<u16> {
+    match role {
+        Role::Chat => vec![8181, 8184, 8185, 8186],
+        Role::Embed => vec![8182, 8187, 8188, 8189],
+        Role::Vision => vec![8183, 8190, 8191, 8192],
+    }
+}
+
 /// One slot's externally-visible state. Returned to the frontend as
 /// part of `LlamaStatus.slots`.
 #[derive(Debug, Clone, Serialize)]
@@ -213,5 +240,26 @@ mod tests {
         let embed = statuses.iter().find(|s| s.role == Role::Embed).unwrap();
         assert!(embed.running);
         assert_eq!(embed.model_id.as_deref(), Some("nomic-embed"));
+    }
+
+    #[test]
+    fn allocator_returns_preferred_when_free() {
+        let probe = |_: u16| true;
+        let port = pick_port(8181, &[8181, 8190], probe);
+        assert_eq!(port, Some(8181));
+    }
+
+    #[test]
+    fn allocator_skips_busy_preferred() {
+        let probe = |p: u16| p != 8181;
+        let port = pick_port(8181, &[8181, 8182], probe);
+        assert_eq!(port, Some(8182));
+    }
+
+    #[test]
+    fn allocator_returns_none_when_all_busy() {
+        let probe = |_: u16| false;
+        let port = pick_port(8181, &[8181, 8182, 8183], probe);
+        assert_eq!(port, None);
     }
 }

--- a/src-tauri/src/slots.rs
+++ b/src-tauri/src/slots.rs
@@ -1,0 +1,77 @@
+//! Concurrent inference slots.
+//!
+//! A "slot" is a running `llama-server` child for a specific role:
+//! Chat, Embed, or Vision. Each slot has its own port, model, and
+//! lifecycle. Today llama.rs hard-coded two slots and tied vision to
+//! the chat slot via `--mmproj`; this module generalises that.
+
+use serde::{Deserialize, Serialize};
+
+/// The roles a llama-server child can fulfil. The string form (the
+/// `serde` tag) is the wire format used by Tauri commands and the
+/// persisted slots.json file — do not rename without a migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Role {
+    Chat,
+    Embed,
+    Vision,
+}
+
+impl Role {
+    pub fn default_port(self) -> u16 {
+        match self {
+            Role::Chat => 8181,
+            Role::Embed => 8182,
+            Role::Vision => 8183,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::Chat => "chat",
+            Role::Embed => "embed",
+            Role::Vision => "vision",
+        }
+    }
+}
+
+/// One slot's externally-visible state. Returned to the frontend as
+/// part of `LlamaStatus.slots`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlotStatus {
+    pub role: Role,
+    pub running: bool,
+    pub port: u16,
+    pub model_id: Option<String>,
+    /// Vision slot only — the matching projector model id. None for
+    /// other roles or when vision is loaded without a separate mmproj.
+    pub mmproj_id: Option<String>,
+    pub pid: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_default_ports_are_distinct() {
+        assert_ne!(Role::Chat.default_port(), Role::Embed.default_port());
+        assert_ne!(Role::Chat.default_port(), Role::Vision.default_port());
+        assert_ne!(Role::Embed.default_port(), Role::Vision.default_port());
+    }
+
+    #[test]
+    fn role_serializes_kebab_case() {
+        let json = serde_json::to_string(&Role::Vision).unwrap();
+        assert_eq!(json, "\"vision\"");
+    }
+
+    #[test]
+    fn role_as_str_matches_serde_tag() {
+        assert_eq!(Role::Chat.as_str(), "chat");
+        assert_eq!(Role::Embed.as_str(), "embed");
+        assert_eq!(Role::Vision.as_str(), "vision");
+    }
+}

--- a/src-tauri/src/slots_persist.rs
+++ b/src-tauri/src/slots_persist.rs
@@ -1,0 +1,92 @@
+//! Persisted "active slots" snapshot. Trivial schema — one model id
+//! per role. We deliberately don't persist port numbers or PIDs;
+//! those are recomputed at restore time.
+
+use crate::config::slots_state_path;
+use crate::slots::Role;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SlotsSnapshot {
+    pub chat_model_id: Option<String>,
+    pub embed_model_id: Option<String>,
+    pub vision_model_id: Option<String>,
+    pub vision_mmproj_id: Option<String>,
+}
+
+pub fn load() -> SlotsSnapshot {
+    let path = slots_state_path();
+    let Ok(bytes) = fs::read(&path) else {
+        return SlotsSnapshot::default();
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
+}
+
+pub fn save(snap: &SlotsSnapshot) -> Result<()> {
+    let path = slots_state_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_vec_pretty(snap)?;
+    fs::write(&path, json)?;
+    Ok(())
+}
+
+pub fn snapshot_from_status(slots: &[crate::slots::SlotStatus]) -> SlotsSnapshot {
+    let mut by_role: HashMap<Role, &crate::slots::SlotStatus> = HashMap::new();
+    for s in slots {
+        if s.running {
+            by_role.insert(s.role, s);
+        }
+    }
+    SlotsSnapshot {
+        chat_model_id: by_role.get(&Role::Chat).and_then(|s| s.model_id.clone()),
+        embed_model_id: by_role.get(&Role::Embed).and_then(|s| s.model_id.clone()),
+        vision_model_id: by_role.get(&Role::Vision).and_then(|s| s.model_id.clone()),
+        vision_mmproj_id: by_role.get(&Role::Vision).and_then(|s| s.mmproj_id.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slots::SlotStatus;
+
+    #[test]
+    fn snapshot_only_includes_running_slots() {
+        let slots = vec![
+            SlotStatus {
+                role: Role::Chat,
+                running: true,
+                port: 8181,
+                model_id: Some("chat-7b".into()),
+                mmproj_id: None,
+                pid: Some(123),
+            },
+            SlotStatus {
+                role: Role::Embed,
+                running: false,
+                port: 8182,
+                model_id: None,
+                mmproj_id: None,
+                pid: None,
+            },
+            SlotStatus {
+                role: Role::Vision,
+                running: true,
+                port: 8183,
+                model_id: Some("llava-7b".into()),
+                mmproj_id: Some("llava-mmproj".into()),
+                pid: Some(456),
+            },
+        ];
+        let snap = snapshot_from_status(&slots);
+        assert_eq!(snap.chat_model_id.as_deref(), Some("chat-7b"));
+        assert_eq!(snap.embed_model_id, None);
+        assert_eq!(snap.vision_model_id.as_deref(), Some("llava-7b"));
+        assert_eq!(snap.vision_mmproj_id.as_deref(), Some("llava-mmproj"));
+    }
+}

--- a/src/components/SlotsPanel.tsx
+++ b/src/components/SlotsPanel.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { Loader2, Play, Square, Cpu, Image as ImageIcon, Database } from "lucide-react";
+import { api } from "../lib/api";
+import { useApp } from "../lib/store";
+import type { Role, InstalledModel } from "../lib/types";
+
+const ROLE_LABEL: Record<Role, string> = {
+  chat: "Chat",
+  embed: "Embedding",
+  vision: "Vision",
+};
+const ROLE_ICON: Record<Role, typeof Cpu> = {
+  chat: Cpu,
+  embed: Database,
+  vision: ImageIcon,
+};
+
+function modelsForRole(installed: InstalledModel[], role: Role): InstalledModel[] {
+  switch (role) {
+    case "chat":
+      return installed.filter((m) => m.kind === "llm");
+    case "embed":
+      return installed.filter((m) => m.kind === "embedding");
+    case "vision":
+      return installed.filter((m) => m.kind === "vision");
+  }
+}
+
+export function SlotsPanel() {
+  const { llama, installed, setLlama } = useApp();
+  const [busy, setBusy] = useState<Role | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load(role: Role, modelId: string) {
+    setBusy(role);
+    setError(null);
+    try {
+      let mmprojId: string | undefined;
+      if (role === "vision") {
+        const model = installed.find((m) => m.id === modelId);
+        const mmprojs = installed.filter((m) => m.kind === "mmproj");
+        mmprojId = (mmprojs.find((m) => m.repo === model?.repo) ?? mmprojs[0])?.id;
+        if (!mmprojId) {
+          throw new Error("vision model needs a matching mmproj projector — download one from the marketplace first");
+        }
+      }
+      const s = await api.startSlot(role, modelId, mmprojId);
+      setLlama(s);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function unload(role: Role) {
+    setBusy(role);
+    setError(null);
+    try {
+      await api.stopSlot(role);
+      const s = await api.llamaStatus();
+      setLlama(s);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {(["chat", "embed", "vision"] as Role[]).map((role) => {
+        const slot = llama.slots?.find((s) => s.role === role);
+        const Icon = ROLE_ICON[role];
+        const candidates = modelsForRole(installed, role);
+        return (
+          <div
+            key={role}
+            className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-3"
+          >
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-9 h-9 rounded-md bg-[var(--color-panel-2)] grid place-items-center text-[var(--color-text-muted)]">
+                <Icon size={16} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium">{ROLE_LABEL[role]} slot</div>
+                <div className="text-xs text-[var(--color-text-muted)] truncate">
+                  {slot?.running ? slot.modelId : "Not loaded"}
+                </div>
+              </div>
+              {slot?.running ? (
+                <button
+                  onClick={() => unload(role)}
+                  disabled={busy === role}
+                  className="flex items-center gap-1 text-xs px-2.5 py-1 rounded-md bg-[var(--color-panel-2)] border border-[var(--color-border)]"
+                >
+                  {busy === role ? <Loader2 size={12} className="animate-spin" /> : <Square size={12} />} unload
+                </button>
+              ) : null}
+            </div>
+            {!slot?.running && (
+              <div className="flex flex-wrap gap-1.5">
+                {candidates.length === 0 && (
+                  <span className="text-xs text-[var(--color-text-subtle)]">
+                    No {role} models on this device — visit the marketplace.
+                  </span>
+                )}
+                {candidates.map((m) => (
+                  <button
+                    key={m.id}
+                    onClick={() => load(role, m.id)}
+                    disabled={busy !== null}
+                    className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-md gradient-accent text-white disabled:opacity-50"
+                  >
+                    <Play size={11} /> {m.filename}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      {error && (
+        <p className="text-xs text-[var(--color-danger)] bg-[var(--color-danger)]/10 rounded-md px-3 py-2">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/slot-routing.test.ts
+++ b/src/lib/__tests__/slot-routing.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { pickSlotPort } from "../slot-routing";
+import type { LlamaStatus, SlotStatus } from "../types";
+
+function status(slots: Partial<SlotStatus>[]): LlamaStatus {
+  return {
+    running: false,
+    port: 8181,
+    modelId: null,
+    mmprojId: null,
+    pid: null,
+    embeddingRunning: false,
+    embeddingPort: 8182,
+    embeddingModelId: null,
+    slots: slots.map((s) => ({
+      role: "chat",
+      running: false,
+      port: 8181,
+      modelId: null,
+      mmprojId: null,
+      pid: null,
+      ...s,
+    })) as SlotStatus[],
+  };
+}
+
+describe("pickSlotPort", () => {
+  it("returns vision port when image present and vision running", () => {
+    const s = status([
+      { role: "chat", running: true, port: 8181 },
+      { role: "vision", running: true, port: 8183 },
+    ]);
+    expect(pickSlotPort(s, true)).toBe(8183);
+  });
+
+  it("falls back to chat when image present but vision not running", () => {
+    const s = status([{ role: "chat", running: true, port: 8181 }]);
+    expect(pickSlotPort(s, true)).toBe(8181);
+  });
+
+  it("uses chat for non-image requests even when vision is running", () => {
+    const s = status([
+      { role: "chat", running: true, port: 8181 },
+      { role: "vision", running: true, port: 8183 },
+    ]);
+    expect(pickSlotPort(s, false)).toBe(8181);
+  });
+
+  it("returns null when no slot can serve", () => {
+    const s = status([]);
+    expect(pickSlotPort(s, false)).toBeNull();
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { isTauri } from "./util";
 import { useApp } from "./store";
+import { pickSlotPort, bodyHasImage } from "./slot-routing";
 import type {
   HardwareInfo,
   InstalledModel,
@@ -171,10 +172,13 @@ export async function* streamChat(
   opts: { temperature?: number; maxTokens?: number; signal?: AbortSignal } = {},
 ): AsyncGenerator<string> {
   const conn = connection();
+  const status = useApp.getState().llama;
+  const hasImage = bodyHasImage(messages);
+  const targetPort = conn ? port : (pickSlotPort(status, hasImage) ?? port);
   const base = conn
     ? conn.url.replace(/\/+$/, "")
     : isTauri()
-    ? `http://127.0.0.1:${port}`
+    ? `http://127.0.0.1:${targetPort}`
     : "";
   const res = await fetch(`${base}/v1/chat/completions`, {
     method: "POST",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -149,6 +149,10 @@ export const api = {
   setKnownSynapseTokens: (tokens: Record<string, string>) =>
     invoke<void>("set_known_synapse_tokens", { tokens }),
   synapseActiveSessions: () => invoke<number>("synapse_active_sessions"),
+  startSlot: (role: import("./types").Role, modelId: string, mmprojId?: string) =>
+    invoke<LlamaStatus>("start_slot", { role, modelId, mmprojId }),
+  stopSlot: (role: import("./types").Role) =>
+    invoke<void>("stop_slot", { role }),
 };
 
 export type ChatContentPart =

--- a/src/lib/slot-routing.ts
+++ b/src/lib/slot-routing.ts
@@ -1,0 +1,36 @@
+import type { LlamaStatus } from "./types";
+
+/**
+ * Mirrors the Rust-side route_chat_port logic. Image-bearing requests
+ * prefer the vision slot when loaded; otherwise (or for text-only
+ * requests) they go to the chat slot. Returns null if no slot can serve.
+ */
+export function pickSlotPort(status: LlamaStatus, hasImage: boolean): number | null {
+  const find = (role: "chat" | "vision") =>
+    status.slots.find((s) => s.role === role && s.running) ?? null;
+  if (hasImage) {
+    const v = find("vision");
+    if (v) return v.port;
+  }
+  const c = find("chat");
+  return c ? c.port : null;
+}
+
+/**
+ * Inspect a chat-completions body to decide if it has any image content.
+ * Used by the desktop direct-call path; the LAN proxy path uses a
+ * server-side equivalent in server.rs.
+ */
+export function bodyHasImage(messages: { content: unknown }[]): boolean {
+  for (const m of messages) {
+    if (typeof m.content === "string") continue;
+    if (Array.isArray(m.content)) {
+      for (const part of m.content) {
+        if (part && typeof part === "object" && (part as { type?: string }).type === "image_url") {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -125,6 +125,11 @@ const emptyLlama: LlamaStatus = {
   embeddingRunning: false,
   embeddingPort: 8182,
   embeddingModelId: null,
+  slots: [
+    { role: "chat", running: false, port: 8181, modelId: null, mmprojId: null, pid: null },
+    { role: "embed", running: false, port: 8182, modelId: null, mmprojId: null, pid: null },
+    { role: "vision", running: false, port: 8183, modelId: null, mmprojId: null, pid: null },
+  ],
 };
 
 export const useApp = create<AppState>()(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -48,6 +48,17 @@ export interface InstalledModel {
   kind: ModelKind;
 }
 
+export type Role = "chat" | "embed" | "vision";
+
+export interface SlotStatus {
+  role: Role;
+  running: boolean;
+  port: number;
+  modelId: string | null;
+  mmprojId: string | null;
+  pid: number | null;
+}
+
 export interface LlamaStatus {
   running: boolean;
   port: number;
@@ -57,6 +68,8 @@ export interface LlamaStatus {
   embeddingRunning: boolean;
   embeddingPort: number;
   embeddingModelId: string | null;
+  /** Canonical per-role view. Always exactly 3 entries: chat / embed / vision. */
+  slots: SlotStatus[];
 }
 
 /** A single Synapse worker the host wants to pipeline-shard layers onto.

--- a/src/pages/Models.tsx
+++ b/src/pages/Models.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
-import { Trash2, Play, Square, Boxes } from "lucide-react";
+import { Trash2, Boxes } from "lucide-react";
 import { api } from "../lib/api";
 import { useApp } from "../lib/store";
 import { formatBytes } from "../lib/util";
+import { SlotsPanel } from "../components/SlotsPanel";
 
 export function Models() {
-  const { installed, setInstalled, activeModelId, setActiveModelId, llama, setLlama, setView, synapse } = useApp();
+  const { installed, setInstalled, setLlama, setView } = useApp();
 
   useEffect(() => {
     api.listInstalledModels().then(setInstalled).catch(console.error);
@@ -17,37 +18,16 @@ export function Models() {
     await api.deleteModel(id);
     const list = await api.listInstalledModels();
     setInstalled(list);
-    if (activeModelId === id) setActiveModelId(null);
-  }
-
-  async function activate(id: string) {
-    setActiveModelId(id);
-    const model = installed.find((m) => m.id === id);
-    const mmprojs = installed.filter((m) => m.kind === "mmproj" || /mmproj/i.test(m.id));
-    const mmprojId = model?.kind === "vision"
-      ? (mmprojs.find((m) => m.repo === model.repo) ?? mmprojs[0])?.id
-      : undefined;
-    const synapseWorkers = synapse.workers.length > 0 ? synapse.workers : undefined;
-    const s = await api.startLlama({
-      modelId: id,
-      mmprojId,
-      synapseWorkers,
-      hostWeight: synapse.hostWeight,
-    });
-    setLlama(s);
-  }
-
-  async function stop() {
-    await api.stopLlama();
-    setLlama({ ...llama, running: false, modelId: null, pid: null });
   }
 
   return (
     <div className="flex flex-col h-full">
       <header className="px-5 py-4 border-b border-[var(--color-border-soft)] flex items-center justify-between">
         <div>
-          <h1 className="font-semibold text-[17px]">My models</h1>
-          <p className="text-[var(--color-text-muted)] text-sm">Manage downloaded models on this device.</p>
+          <h1 className="font-semibold text-[17px]">Active slots</h1>
+          <p className="text-[var(--color-text-muted)] text-sm">
+            Load chat, embedding, and vision models concurrently.
+          </p>
         </div>
         <button
           onClick={() => setView("marketplace")}
@@ -58,58 +38,34 @@ export function Models() {
       </header>
 
       <div className="flex-1 overflow-y-auto px-5 py-4">
+        <SlotsPanel />
+
+        <h2 className="text-sm font-medium mt-6 mb-2">Library</h2>
         {installed.length === 0 ? (
-          <div className="text-center py-16 text-[var(--color-text-muted)]">
-            <p className="mb-3">No models yet.</p>
-            <button
-              onClick={() => setView("marketplace")}
-              className="px-4 py-2 rounded-md gradient-accent text-white text-sm font-medium"
-            >
-              Open marketplace →
-            </button>
-          </div>
+          <p className="text-xs text-[var(--color-text-muted)]">
+            No models yet. Open the marketplace to download one.
+          </p>
         ) : (
           <div className="flex flex-col gap-2">
-            {installed.map((m) => {
-              const running = llama.running && llama.modelId === m.id;
-              return (
-                <div
-                  key={m.id}
-                  className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-3 flex items-center gap-3"
-                >
-                  <div className="w-9 h-9 rounded-md bg-[var(--color-panel-2)] grid place-items-center text-[var(--color-text-muted)]">
-                    <Boxes size={16} />
+            {installed.map((m) => (
+              <div
+                key={m.id}
+                className="rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] p-3 flex items-center gap-3"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm truncate">{m.filename}</div>
+                  <div className="text-xs text-[var(--color-text-muted)] truncate">
+                    {m.repo !== "local" ? m.repo : "Local file"} · {formatBytes(m.sizeBytes)} · {m.kind}
                   </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate">{m.filename}</div>
-                    <div className="text-xs text-[var(--color-text-muted)] truncate">
-                      {m.repo !== "local" ? m.repo : "Local file"} · {formatBytes(m.sizeBytes)} · {m.kind}
-                    </div>
-                  </div>
-                  {running ? (
-                    <button
-                      onClick={stop}
-                      className="flex items-center gap-1 text-xs px-2.5 py-1 rounded-md bg-[var(--color-panel-2)] border border-[var(--color-border)]"
-                    >
-                      <Square size={12} /> stop
-                    </button>
-                  ) : (
-                    <button
-                      onClick={() => activate(m.id)}
-                      className="flex items-center gap-1 text-xs px-2.5 py-1 rounded-md gradient-accent text-white"
-                    >
-                      <Play size={12} /> load
-                    </button>
-                  )}
-                  <button
-                    onClick={() => remove(m.id)}
-                    className="text-[var(--color-text-subtle)] hover:text-[var(--color-danger)] p-1"
-                  >
-                    <Trash2 size={15} />
-                  </button>
                 </div>
-              );
-            })}
+                <button
+                  onClick={() => remove(m.id)}
+                  className="text-[var(--color-text-subtle)] hover:text-[var(--color-danger)] p-1"
+                >
+                  <Trash2 size={15} />
+                </button>
+              </div>
+            ))}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Refactors LocalMind's llama.cpp orchestration so chat, embedding, and vision models can run concurrently in one session. Today \`llama.rs\` hard-codes two slots (chat + embed) as \`Mutex<ServerHandle>\` fields and ties vision to the chat slot via \`--mmproj\`. After this PR, \`LlamaState\` is backed by a generic \`SlotTable\` keyed by \`Role { Chat, Embed, Vision }\` — three independent llama-server children, each with its own port, model, and lifecycle.

### Architecture

- **\`src-tauri/src/slots.rs\`** — \`Role\` enum (kebab-case serde — wire format), \`SlotStatus\`, \`SlotEntry\`, \`SlotTable\` with insert/get/remove/statuses. Plus \`pick_port\` (preferred → pool fallback), \`port_pool\`, \`available_gpu_memory_gb\`, \`estimate_slot_vram_gb\`, \`fits_with_existing\`. **17 unit tests** cover the lot.
- **\`LlamaState\` refactor** — internal storage is now \`Mutex<SlotTable>\`. Public methods (\`start\`, \`stop\`, \`start_embedding\`, \`stop_embedding\`, \`status\`, \`embedding_port\`, \`embedding_running\`) keep their signatures. Adds \`start_vision\`, \`stop_vision\`, \`route_chat_port\`.
- **VRAM pre-flight** — every \`start*\` calls \`preflight_vram\` before spawning. Refuses with a user-readable message when the requested model would push total estimated VRAM past 70% of unified memory (Apple Silicon) or full reported VRAM (dedicated GPUs). CPU-only systems skip the check.
- **Smart routing** — \`server.rs::proxy_v1\` scans the chat-completions body for the literal \`\"image_url\"\` (via \`memchr\`) and routes to the vision slot when present and loaded; otherwise to chat. Same logic mirrored client-side via \`pickSlotPort\` + \`bodyHasImage\` for the desktop direct-call path.
- **Persistence** — \`data_dir/slots.json\` records active model ids per role; saved on every successful slot transition; restored from \`setup()\` on app boot. Failures during restore log and continue (a missing model file shouldn't block the app).
- **\`LlamaStatus\`** — added \`slots: SlotStatus[]\`. Legacy flat fields (\`running\`, \`port\`, \`modelId\`, \`embeddingRunning\`, etc.) stay populated for one release so the existing frontend keeps working.
- **Tauri commands** — new \`start_slot(role, model_id, mmproj_id?)\` and \`stop_slot(role)\`. Existing \`start_llama\`/\`stop_llama\`/etc. unchanged.
- **UI** — \`Models.tsx\` body becomes \"Active slots\" with three role cards (chat / embed / vision) loading from the matching kind in the installed library.

### Plan deviations (worth noting in review)

- **TDD test runtime fix:** Plan's SlotTable tests used \`tokio::process::Command::spawn()\` inside \`#[test]\` which panics (no tokio reactor). Switched the affected tests to \`#[tokio::test] async fn\` (\`fa1da91\`).
- **Tauri command error type:** Plan's \`start_slot\` used \`.ok_or_else(|| anyhow::anyhow!(...))?\` but the command returns \`Result<_, String>\` so the trait conversion fails. Switched to a String error directly (\`b796936\`).
- **Clippy \`-D warnings\`:** \`Role::as_str\` and \`LlamaState::vision_slot\` are part of the API surface for future plans (Synapse panel UI, plugin events) but unused right now. \`#[allow(dead_code)]\` rather than trimming and re-adding (\`2731f72\`).

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` — 35 Rust tests passing (existing + 17 new slot tests + 1 slots_persist test)
- [x] \`npm run typecheck\` clean
- [x] \`npm run test:run\` — 13 frontend tests passing (existing 9 + 4 new slot-routing)
- [ ] On-device three-slot smoke test (chat + embed + vision loaded concurrently)
- [ ] Image-bearing chat request routes to vision slot
- [ ] Restart app → \`slots.json\` auto-restores all three slots
- [ ] VRAM rejection: load a 14 GB model on a 16 GB Mac, then try a second 14 GB → expect clear error, first slot remains running

## Notes

- \`ROADMAP.md\` lives on \`feature/roadmap-next\` (separate planning branch); the matching \"Shipped\" line will land there before that branch's PR.
- The Synapse host-proxy lifecycle is intentionally kept tied to the **chat** slot only — embed and vision never pipeline across workers, since pipeline-parallel inference for those use cases doesn't make sense.